### PR TITLE
lib: Fix kernel version parsing

### DIFF
--- a/lib/topotest.py
+++ b/lib/topotest.py
@@ -157,9 +157,10 @@ class Router(Node):
             if not os.path.isfile('/usr/lib/%s/ldpd' % self.routertype):
                 print("LDP Test, but no ldpd compiled or installed")
                 return "LDP Test, but no ldpd compiled or installed"
-            kernel_version = re.search(r'([0-9]+\.[0-9]+).*', platform.release())
+            kernel_version = re.search(r'([0-9]+)\.([0-9]+).*', platform.release())
+
             if kernel_version:
-                if float(kernel_version.group(1)) < 4.5:
+                if float(kernel_version.group(1)) < 4 and float(kernel.version.group(2)) < 5:
                     print("LDP Test need Linux Kernel 4.5 minimum")
                     return "LDP Test need Linux Kernel 4.5 minimum"
         # Add mpls modules to kernel if we use LDP

--- a/lib/topotest.py
+++ b/lib/topotest.py
@@ -160,7 +160,8 @@ class Router(Node):
             kernel_version = re.search(r'([0-9]+)\.([0-9]+).*', platform.release())
 
             if kernel_version:
-                if float(kernel_version.group(1)) < 4 and float(kernel.version.group(2)) < 5:
+                if float(kernel_version.group(1)) < 4 or
+                   (float(kernel_version.group(1)) == 4 and float(kernel.version.group(2)) < 5):
                     print("LDP Test need Linux Kernel 4.5 minimum")
                     return "LDP Test need Linux Kernel 4.5 minimum"
         # Add mpls modules to kernel if we use LDP


### PR DESCRIPTION
When we have a kernel sub version > 10 the float conversion
of the kernel version causes 4.10 to be less than 4.5

Get the kernel version in groups on <major>.<minor> and do
comparison that way

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>