### PR TITLE
Topogen Configuration File

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -44,8 +44,13 @@ r1-zebra.out # zebra stdout output
 You can also run memory leak tests to get reports:
 
 ```shell
+$ # Set the environment variable to apply to a specific test...
 $ sudo env TOPOTESTS_CHECK_MEMLEAK="/tmp/memleak_report_" pytest ospf-topo1/test_ospf_topo1.py
-...
+$ # ...or apply to all tests adding this line to the configuration file
+$ echo 'memleak_path = /tmp/memleak_report_' >> pytest.ini
+$ # You can also use your editor
+$ $EDITOR pytest.ini
+$ # After running tests you should see your files:
 $ ls /tmp/memleak_report_*
 memleak_report_test_ospf_topo1.txt
 ```

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -552,3 +552,15 @@ r1
 *** Starting CLI:
 mininet>
 ```
+
+To enable more debug messages in other Topogen subsystems (like Mininet), more
+logging messages can be displayed by modifying the test configuration file
+`pytest.ini`:
+
+```ini
+[topogen]
+# Change the default verbosity line from 'info'...
+#verbosity = info
+# ...to 'debug'
+verbosity = debug
+```

--- a/lib/topogen.py
+++ b/lib/topogen.py
@@ -123,6 +123,7 @@ class Topogen(object):
             'frrdir': '/usr/lib/frr',
             'quaggadir': '/usr/lib/quagga',
             'routertype': 'frr',
+            'memleak_path': None,
         }
         self.config = ConfigParser.ConfigParser(defaults)
         pytestini_path = os.path.join(CWD, '../pytest.ini')
@@ -144,6 +145,7 @@ class Topogen(object):
 
         params['frrdir'] = self.config.get(self.CONFIG_SECTION, 'frrdir')
         params['quaggadir'] = self.config.get(self.CONFIG_SECTION, 'quaggadir')
+        params['memleak_path'] = self.config.get(self.CONFIG_SECTION, 'memleak_path')
         if not params.has_key('routertype'):
             params['routertype'] = self.config.get(self.CONFIG_SECTION, 'routertype')
 
@@ -388,8 +390,11 @@ class TopoRouter(TopoGear):
         self.net = None
         self.name = name
         self.cls = cls
+        self.options = {}
         if not params.has_key('privateDirs'):
             params['privateDirs'] = self.PRIVATE_DIRS
+
+        self.options['memleak_path'] = params.get('memleak_path', None)
         self.tgen.topo.addNode(self.name, cls=self.cls, **params)
 
     def __str__(self):
@@ -472,9 +477,9 @@ class TopoRouter(TopoGear):
         testname: the test file name for identification
 
         NOTE: to run this you must have the environment variable
-        TOPOTESTS_CHECK_MEMLEAK set to the appropriated path.
+        TOPOTESTS_CHECK_MEMLEAK set or memleak_path configured in `pytest.ini`.
         """
-        memleak_file = os.environ.get('TOPOTESTS_CHECK_MEMLEAK')
+        memleak_file = os.environ.get('TOPOTESTS_CHECK_MEMLEAK') or self.options['memleak_path']
         if memleak_file is None:
             print "SKIPPED check on Memory leaks: Disabled (TOPOTESTS_CHECK_MEMLEAK undefined)"
             return

--- a/lib/topogen.py
+++ b/lib/topogen.py
@@ -41,12 +41,15 @@ Basic usage instructions:
 import os
 import sys
 import json
+import ConfigParser
 
 from mininet.net import Mininet
 from mininet.log import setLogLevel
 from mininet.cli import CLI
 
 from lib import topotest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
 
 # pylint: disable=C0103
 # Global Topogen variable. This is being used to keep the Topogen available on
@@ -75,7 +78,10 @@ def set_topogen(tgen):
 class Topogen(object):
     "A topology test builder helper."
 
+    CONFIG_SECTION = 'topogen'
+
     def __init__(self, cls):
+        self.config = None
         self.topo = None
         self.net = None
         self.gears = {}
@@ -97,6 +103,9 @@ class Topogen(object):
         # Set the global variable so the test cases can access it anywhere
         set_topogen(self)
 
+        # Load the default topology configurations
+        self._load_config()
+
         # Initialize the API
         self._mininet_reset()
         cls()
@@ -104,17 +113,39 @@ class Topogen(object):
         for gear in self.gears.values():
             gear.net = self.net
 
+    def _load_config(self):
+        """
+        Loads the configuration file `pytest.ini` located at the root dir of
+        topotests.
+        """
+        defaults = {
+            'verbosity': 'info',
+            'frrdir': '/usr/lib/frr',
+            'quaggadir': '/usr/lib/quagga',
+            'routertype': 'frr',
+        }
+        self.config = ConfigParser.ConfigParser(defaults)
+        pytestini_path = os.path.join(CWD, '../pytest.ini')
+        self.config.read(pytestini_path)
+
     def add_router(self, name=None, cls=topotest.Router, **params):
         """
         Adds a new router to the topology. This function has the following
         options:
-        name: (optional) select the router name
+        * `name`: (optional) select the router name
+        * `daemondir`: (optional) custom daemon binary directory
+        * `routertype`: (optional) `quagga` or `frr`
         Returns a TopoRouter.
         """
         if name is None:
             name = 'r{}'.format(self.routern)
         if name in self.gears:
             raise KeyError('router already exists')
+
+        params['frrdir'] = self.config.get(self.CONFIG_SECTION, 'frrdir')
+        params['quaggadir'] = self.config.get(self.CONFIG_SECTION, 'quaggadir')
+        if not params.has_key('routertype'):
+            params['routertype'] = self.config.get(self.CONFIG_SECTION, 'routertype')
 
         self.gears[name] = TopoRouter(self, cls, name, **params)
         self.routern += 1
@@ -167,7 +198,7 @@ class Topogen(object):
         return dict((rname, gear) for rname, gear in self.gears.iteritems()
                     if isinstance(gear, TopoRouter))
 
-    def start_topology(self, log_level='info'):
+    def start_topology(self, log_level=None):
         """
         Starts the topology class. Possible `log_level`s are:
         'debug': all information possible
@@ -177,6 +208,10 @@ class Topogen(object):
         'error': only error and critical messages
         'critical': only critical messages
         """
+        # If log_level is not specified use the configuration.
+        if log_level is None:
+            log_level = self.config.get('topogen', 'verbosity')
+
         # Run mininet
         setLogLevel(log_level)
         self.net.start()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,19 @@
 # Skip pytests example directory
 [pytest]
 norecursedirs = .git example-test
+
+[topogen]
+# Default configuration values
+#
+# 'verbosity' controls how much data the underline systems will use to
+# provide output (e.g. mininet output, test debug output etc...). The
+# value is 'info', but can be changed to 'debug' to provide more details.
+#verbosity = info
+
+# Default daemons binaries path.
+#frrdir = /usr/lib/frr
+#quaggadir = /usr/lib/quagga
+
+# Default router type to use. Possible values are:
+# 'frr' and 'quagga'.
+#routertype = frr

--- a/pytest.ini
+++ b/pytest.ini
@@ -17,3 +17,11 @@ norecursedirs = .git example-test
 # Default router type to use. Possible values are:
 # 'frr' and 'quagga'.
 #routertype = frr
+
+# Memory leak test reports path
+# Enables and add an output path to memory leak tests.
+# Example:
+# memleak_path = /tmp/memleak_
+# Output files will be named after the testname:
+# /tmp/memleak_test_ospf_topo1.txt
+#memleak_path =


### PR DESCRIPTION
Add support for a configuration file.

Currently the code re-uses the pytest.ini to load its configuration and has the following options:

* `verbosity`: allows to change the default verbosity of tests, so we don't have to touch test files to enable debugs.
* `frrdir` and `quaggadir`: allows non-default FRR or Quagga installation paths
* `routertype`: allows running topotest using a non-default router type (we only have `quagga` now)
* `memleak_path`: active memory leak tests without using environment variables and apply it globally for all tests

The options and defaults are already listed in pytest.ini commented out.