### PR TITLE
topogen improvements

### DIFF
--- a/example-test/test_template.py
+++ b/example-test/test_template.py
@@ -99,6 +99,10 @@ def teardown_module(mod):
 def test_call_mininet_cli():
     "Dummy test that just calls mininet CLI so we can interact with the build."
     tgen = get_topogen()
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
     logger.info('calling mininet CLI')
     tgen.mininet_cli()
 

--- a/lib/test/test_json.py
+++ b/lib/test/test_json.py
@@ -249,5 +249,85 @@ def test_json_intersect_multilevel_false():
     assert json_cmp(dcomplete, dsub5) is not None
     assert json_cmp(dcomplete, dsub6) is not None
 
+def test_json_with_list_sucess():
+    "Test successful json comparisons that have lists."
+
+    dcomplete = {
+        'list': [
+            {
+                'i1': 'item 1',
+                'i2': 'item 2',
+            },
+            {
+                'i10': 'item 10',
+            },
+        ],
+        'i100': 'item 100',
+    }
+
+    # Test list type
+    dsub1 = {
+        'list': [],
+    }
+    # Test list correct list items
+    dsub2 = {
+        'list': [
+            {
+                'i1': 'item 1',
+            },
+        ],
+        'i100': 'item 100',
+    }
+    # Test list correct list size
+    dsub3 = {
+        'list': [
+            {}, {},
+        ],
+    }
+
+    assert json_cmp(dcomplete, dsub1) is None
+    assert json_cmp(dcomplete, dsub2) is None
+    assert json_cmp(dcomplete, dsub3) is None
+
+def test_json_with_list_failure():
+    "Test failed json comparisons that have lists."
+
+    dcomplete = {
+        'list': [
+            {
+                'i1': 'item 1',
+                'i2': 'item 2',
+            },
+            {
+                'i10': 'item 10',
+            },
+        ],
+        'i100': 'item 100',
+    }
+
+    # Test list type
+    dsub1 = {
+        'list': {},
+    }
+    # Test list incorrect list items
+    dsub2 = {
+        'list': [
+            {
+                'i1': 'item 2',
+            },
+        ],
+        'i100': 'item 100',
+    }
+    # Test list correct list size
+    dsub3 = {
+        'list': [
+            {}, {}, {},
+        ],
+    }
+
+    assert json_cmp(dcomplete, dsub1) is not None
+    assert json_cmp(dcomplete, dsub2) is not None
+    assert json_cmp(dcomplete, dsub3) is not None
+
 if __name__ == '__main__':
     sys.exit(pytest.main())

--- a/lib/test/test_version.py
+++ b/lib/test/test_version.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+
+#
+# test_version.py
+# Tests for library function: version_cmp().
+#
+# Copyright (c) 2017 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+Tests for the version_cmp() function.
+"""
+
+import os
+import sys
+import pytest
+
+# Save the Current Working Directory to find lib files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, '../../'))
+
+# pylint: disable=C0413
+from lib.topotest import version_cmp
+
+def test_valid_versions():
+    "Test valid version compare results"
+
+    curver = '3.0'
+    samever = '3'
+    oldver = '2.0'
+    newver = '3.0.1'
+    newerver = '3.0.11'
+    vercustom = '3.0-dev'
+    verysmallinc = '3.0.0.0.0.0.0.1'
+
+    assert version_cmp(curver, oldver) == 1
+    assert version_cmp(curver, newver) == -1
+    assert version_cmp(curver, curver) == 0
+    assert version_cmp(curver, newerver) == -1
+    assert version_cmp(newver, newerver) == -1
+    assert version_cmp(curver, samever) == 0
+    assert version_cmp(curver, vercustom) == 0
+    assert version_cmp(vercustom, vercustom) == 0
+    assert version_cmp(vercustom, oldver) == 1
+    assert version_cmp(vercustom, newver) == -1
+    assert version_cmp(vercustom, samever) == 0
+    assert version_cmp(curver, verysmallinc) == -1
+    assert version_cmp(newver, verysmallinc) == 1
+    assert version_cmp(verysmallinc, verysmallinc) == 0
+    assert version_cmp(vercustom, verysmallinc) == -1
+
+def test_invalid_versions():
+    "Test invalid version strings"
+
+    curver = '3.0'
+    badver1 = '.1'
+    badver2 = '-1.0'
+    badver3 = '.'
+    badver4 = '3.-0.3'
+
+    with pytest.raises(ValueError):
+        assert version_cmp(curver, badver1)
+        assert version_cmp(curver, badver2)
+        assert version_cmp(curver, badver3)
+        assert version_cmp(curver, badver4)

--- a/lib/topogen.py
+++ b/lib/topogen.py
@@ -96,6 +96,7 @@ class Topogen(object):
         self.routern = 1
         self.switchn = 1
         self.modname = modname
+        self.errors = {}
         self._init_topo(cls)
         logger.info('loading topology: {}'.format(self.modname))
 
@@ -293,6 +294,19 @@ class Topogen(object):
         for router in router_list:
             router.report_memory_leaks(self.modname)
 
+    def set_error(self, message, code=None):
+        "Sets an error message and signal other tests to skip."
+        logger.error(message)
+
+        # If no code is defined use a sequential number
+        if code is None:
+            code = len(self.errors)
+
+        self.errors[code] = message
+
+    def has_errors(self):
+        "Returns whether errors exist or not."
+        return len(self.errors) > 0
 
 #
 # Topology gears (equipment)

--- a/lib/topogen.py
+++ b/lib/topogen.py
@@ -693,6 +693,50 @@ class TopoRouter(TopoGear):
         self.logger.info('running memory leak report')
         self.tgen.net[self.name].report_memory_leaks(memleak_file, testname)
 
+    def version_info(self):
+        "Get equipment information from 'show version'."
+        output = self.vtysh_cmd('show version').split('\n')[0]
+        columns = topotest.normalize_text(output).split(' ')
+        return {
+            'type': columns[0],
+            'version': columns[1],
+        }
+
+    def has_version(self, cmpop, version):
+        """
+        Compares router version using operation `cmpop` with `version`.
+        Valid `cmpop` values:
+        * `>=`: has the same version or greater
+        * '>': has greater version
+        * '=': has the same version
+        * '<': has a lesser version
+        * '<=': has the same version or lesser
+
+        Usage example: router.has_version('>', '1.0')
+        """
+        rversion = self.version_info()['version']
+        result = topotest.version_cmp(rversion, version)
+        if cmpop == '>=':
+            return result >= 0
+        if cmpop == '>':
+            return result > 0
+        if cmpop == '=':
+            return result == 0
+        if cmpop == '<':
+            return result < 0
+        if cmpop == '<':
+            return result < 0
+        if cmpop == '<=':
+            return result <= 0
+
+    def has_type(self, rtype):
+        """
+        Compares router type with `rtype`. Returns `True` if the type matches,
+        otherwise `false`.
+        """
+        curtype = self.version_info()['type']
+        return rtype == curtype
+
 class TopoSwitch(TopoGear):
     """
     Switch abstraction. Has the following properties:

--- a/lib/topogen.py
+++ b/lib/topogen.py
@@ -645,7 +645,11 @@ class TopoRouter(TopoGear):
         if isjson is False:
             return output
 
-        return json.loads(output)
+        try:
+            return json.loads(output)
+        except ValueError:
+            logger.warning('vtysh_cmd: failed to convert json output')
+            return {}
 
     def vtysh_multicmd(self, commands, pretty_output=True):
         """

--- a/lib/topogen.py
+++ b/lib/topogen.py
@@ -250,8 +250,16 @@ class Topogen(object):
             router.start()
 
     def stop_topology(self):
-        "Stops the network topology"
+        """
+        Stops the network topology. This function will call the stop() function
+        of all gears before calling the mininet stop function, so they can have
+        their oportunity to do a graceful shutdown.
+        """
         logger.info('stopping topology: {}'.format(self.modname))
+
+        for gear in self.gears.values():
+            gear.stop()
+
         self.net.stop()
 
     def mininet_cli(self):
@@ -309,6 +317,14 @@ class TopoGear(object):
             links += '"{}"<->"{}"'.format(myif, destif)
 
         return 'TopoGear<name="{}",links=[{}]>'.format(self.name, links)
+
+    def start(self):
+        "Basic start function that just reports equipment start"
+        logger.info('starting "{}"'.format(self.name))
+
+    def stop(self):
+        "Basic start function that just reports equipment stop"
+        logger.info('stopping "{}"'.format(self.name))
 
     def run(self, command):
         """

--- a/lib/topogen.py
+++ b/lib/topogen.py
@@ -322,7 +322,8 @@ class Topogen(object):
 
     def is_memleak_enabled(self):
         "Returns `True` if memory leak report is enable, otherwise `False`."
-        memleak_file = os.environ.get('TOPOTESTS_CHECK_MEMLEAK')
+        memleak_file = (os.environ.get('TOPOTESTS_CHECK_MEMLEAK') or
+                        self.config.get(self.CONFIG_SECTION, 'memleak_path'))
         if memleak_file is None:
             return False
         return True

--- a/lib/topotest.py
+++ b/lib/topotest.py
@@ -224,6 +224,14 @@ def get_file(content):
     fde.close()
     return fname
 
+def normalize_text(text):
+    """
+    Strips formating spaces/tabs and carriage returns.
+    """
+    text = re.sub(r'[ \t]+', ' ', text)
+    text = re.sub(r'\r', '', text)
+    return text
+
 def checkAddressSanitizerError(output, router, component):
     "Checks for AddressSanitizer in output. If found, then logs it and returns true, false otherwise"
 

--- a/lib/topotest.py
+++ b/lib/topotest.py
@@ -232,6 +232,61 @@ def normalize_text(text):
     text = re.sub(r'\r', '', text)
     return text
 
+def version_cmp(v1, v2):
+    """
+    Compare two version strings and returns:
+
+    * `-1`: if `v1` is less than `v2`
+    * `0`: if `v1` is equal to `v2`
+    * `1`: if `v1` is greater than `v2`
+
+    Raises `ValueError` if versions are not well formated.
+    """
+    vregex = r'(?P<whole>\d+(\.(\d+))*)'
+    v1m = re.match(vregex, v1)
+    v2m = re.match(vregex, v2)
+    if v1m is None or v2m is None:
+        raise ValueError("got a invalid version string")
+
+    # Split values
+    v1g = v1m.group('whole').split('.')
+    v2g = v2m.group('whole').split('.')
+
+    # Get the longest version string
+    vnum = len(v1g)
+    if len(v2g) > vnum:
+        vnum = len(v2g)
+
+    # Reverse list because we are going to pop the tail
+    v1g.reverse()
+    v2g.reverse()
+    for _ in range(vnum):
+        try:
+            v1n = int(v1g.pop())
+        except IndexError:
+            while v2g:
+                v2n = int(v2g.pop())
+                if v2n > 0:
+                    return -1
+            break
+
+        try:
+            v2n = int(v2g.pop())
+        except IndexError:
+            if v1n > 0:
+                return 1
+            while v1g:
+                v1n = int(v1g.pop())
+                if v1n > 0:
+                    return -1
+            break
+
+        if v1n > v2n:
+            return 1
+        if v1n < v2n:
+            return -1
+    return 0
+
 def checkAddressSanitizerError(output, router, component):
     "Checks for AddressSanitizer in output. If found, then logs it and returns true, false otherwise"
 


### PR DESCRIPTION
This is a collection of improvements to the topology generator Topogen to make writing tests easier and quicker.

Changelog:

* Add support for generic hosts (TopoHost) and ExaBGP peers (TopoExaBGP)
* TopoGear (the super class which all other types derives) now implements start()/stop(), so sub-classes can use it to implement startup/teardown function for equipments that will be called on pytest start and at the end
* Added error propagation capabilities. Using global variables for this is no longer necessary.
* Added support for list compare inside JSON data structures. json_cmp() now do the following additional checks: check for list item count (expect item count, expect declared items to exist at least once, expect list type)
* Added 'check_router_running' abstraction to avoid boiler plate tests (see the updated template file)