### PR TITLE
topotest diagnostics

### DIFF
--- a/bgp_multiview_topo1/peer1/exabgp.cfg
+++ b/bgp_multiview_topo1/peer1/exabgp.cfg
@@ -1,11 +1,11 @@
 group controller {
 
     process announce-routes {
-        run "./exa-send.py 1 10";
+        run "/etc/exabgp/exa-send.py 1 10";
     }
 
     process receive-routes {
-        run "./exa-receive.py 1";
+        run "/etc/exabgp/exa-receive.py 1";
         receive-routes;
         encoder text;
     }

--- a/bgp_multiview_topo1/peer2/exabgp.cfg
+++ b/bgp_multiview_topo1/peer2/exabgp.cfg
@@ -1,11 +1,11 @@
 group controller {
 
     process announce-routes {
-        run "./exa-send.py 2 10";
+        run "/etc/exabgp/exa-send.py 2 10";
     }
 
     process receive-routes {
-        run "./exa-receive.py 2";
+        run "/etc/exabgp/exa-receive.py 2";
         receive-routes;
         encoder text;
     }

--- a/bgp_multiview_topo1/peer3/exabgp.cfg
+++ b/bgp_multiview_topo1/peer3/exabgp.cfg
@@ -1,11 +1,11 @@
 group controller {
 
     process announce-routes {
-        run "./exa-send.py 3 10";
+        run "/etc/exabgp/exa-send.py 3 10";
     }
 
     process receive-routes {
-        run "./exa-receive.py 3";
+        run "/etc/exabgp/exa-receive.py 3";
         receive-routes;
         encoder text;
     }

--- a/bgp_multiview_topo1/peer4/exabgp.cfg
+++ b/bgp_multiview_topo1/peer4/exabgp.cfg
@@ -1,11 +1,11 @@
 group controller {
 
     process announce-routes {
-        run "./exa-send.py 4 10";
+        run "/etc/exabgp/exa-send.py 4 10";
     }
 
     process receive-routes {
-        run "./exa-receive.py 4";
+        run "/etc/exabgp/exa-receive.py 4";
         receive-routes;
         encoder text;
     }

--- a/bgp_multiview_topo1/peer5/exabgp.cfg
+++ b/bgp_multiview_topo1/peer5/exabgp.cfg
@@ -1,11 +1,11 @@
 group controller {
 
     process announce-routes {
-        run "./exa-send.py 5 10";
+        run "/etc/exabgp/exa-send.py 5 10";
     }
 
     process receive-routes {
-        run "./exa-receive.py 5";
+        run "/etc/exabgp/exa-receive.py 5";
         receive-routes;
         encoder text;
     }

--- a/bgp_multiview_topo1/peer6/exabgp.cfg
+++ b/bgp_multiview_topo1/peer6/exabgp.cfg
@@ -1,11 +1,11 @@
 group controller {
 
     process announce-routes {
-        run "./exa-send.py 6 10";
+        run "/etc/exabgp/exa-send.py 6 10";
     }
 
     process receive-routes {
-        run "./exa-receive.py 6";
+        run "/etc/exabgp/exa-receive.py 6";
         receive-routes;
         encoder text;
     }

--- a/bgp_multiview_topo1/peer7/exabgp.cfg
+++ b/bgp_multiview_topo1/peer7/exabgp.cfg
@@ -1,11 +1,11 @@
 group controller {
 
     process announce-routes {
-        run "./exa-send.py 7 10";
+        run "/etc/exabgp/exa-send.py 7 10";
     }
 
     process receive-routes {
-        run "./exa-receive.py 7";
+        run "/etc/exabgp/exa-receive.py 7";
         receive-routes;
         encoder text;
     }

--- a/bgp_multiview_topo1/peer8/exabgp.cfg
+++ b/bgp_multiview_topo1/peer8/exabgp.cfg
@@ -1,11 +1,11 @@
 group controller {
 
     process announce-routes {
-        run "./exa-send.py 8 10";
+        run "/etc/exabgp/exa-send.py 8 10";
     }
 
     process receive-routes {
-        run "./exa-receive.py 8";
+        run "/etc/exabgp/exa-receive.py 8";
         receive-routes;
         encoder text;
     }

--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,7 @@
 Topotest conftest.py file.
 """
 
-from lib.topogen import get_topogen
+from lib.topogen import get_topogen, diagnose_env
 from lib.topotest import json_cmp_result
 import pytest
 
@@ -40,3 +40,8 @@ def pytest_assertrepr_compare(op, left, right):
             return None
 
     return json_result.errors
+
+def pytest_configure(config):
+    "Assert that the environment is correctly configured."
+    if not diagnose_env():
+        pytest.exit('enviroment has errors, please read the logs')

--- a/lib/topogen.py
+++ b/lib/topogen.py
@@ -885,10 +885,12 @@ def diagnose_env():
 
     # Assert that FRR utilities exist
     frrdir = config.get('topogen', 'frrdir')
+    hasfrr = False
     if not os.path.isdir(frrdir):
         logger.error('could not find {} directory'.format(frrdir))
         ret = False
     else:
+        hasfrr = True
         try:
             pwd.getpwnam('frr')[2]
         except KeyError:
@@ -920,9 +922,13 @@ def diagnose_env():
 
     # Assert that Quagga utilities exist
     quaggadir = config.get('topogen', 'quaggadir')
-    if not os.path.isdir(quaggadir):
+    if hasfrr:
+        # if we have frr, don't check for quagga
+        pass
+    elif not os.path.isdir(quaggadir):
         logger.info('could not find {} directory (quagga tests will not run)'.format(quaggadir))
     else:
+        ret = True
         try:
             pwd.getpwnam('quagga')[2]
         except KeyError:
@@ -937,7 +943,7 @@ def diagnose_env():
             if 'quagga' not in grp.getgrnam('quaggavty').gr_mem:
                 logger.error('"quagga" user and group exist, but user is not under "quaggavty"')
         except KeyError:
-            logger.warning('could not find "frrvty" group')
+            logger.warning('could not find "quaggavty" group')
 
         for fname in ['zebra', 'ospfd', 'ospf6d', 'bgpd', 'ripd', 'ripngd',
                       'isisd', 'pimd']:

--- a/lib/topotest.py
+++ b/lib/topotest.py
@@ -478,13 +478,10 @@ class Router(Node):
             if not os.path.isfile(ldpd_path):
                 logger.warning("LDP Test, but no ldpd compiled or installed")
                 return "LDP Test, but no ldpd compiled or installed"
-            kernel_version = re.search(r'([0-9]+)\.([0-9]+).*', platform.release())
 
-            if kernel_version:
-                if (float(kernel_version.group(1)) < 4 or
-                   (float(kernel_version.group(1)) == 4 and float(kernel_version.group(2)) < 5)):
-                    logger.warning("LDP Test need Linux Kernel 4.5 minimum")
-                    return "LDP Test need Linux Kernel 4.5 minimum"
+            if version_cmp(platform.release(), '4.5') < 0:
+                logger.warning("LDP Test need Linux Kernel 4.5 minimum")
+                return "LDP Test need Linux Kernel 4.5 minimum"
 
             self.cmd('/sbin/modprobe mpls-router')
             self.cmd('/sbin/modprobe mpls-iptunnel')


### PR DESCRIPTION
I've implemented an environment diagnostics routine that runs on every pytest initialization. This routine detects common mistakes on the environment configuration that usually causes silent errors.

The main objective here is to make errors clearer to new topotest adopters, so when they get non-working tests they might look at execution log and get clues.

Currently diagnostics are detecting the following errors:

* Bad FRR instalations (will abort on critical errors)
* Bad Quagga installations
* Look for required packages: mininet, gdb, iproute
* check exabgp version
* check for /tmp
* check ldp/mpls dependencies

I'm also sneaking in two other commits in this PR:

1. fix bgp_multiview_topo1 exabgp configuration to run on more linux distros
2. simplify router kernel check code