### PR TITLE
Fixes to run topotest on ARM7 testbeds (and more reliable on other systems)

### DIFF
--- a/lib/topotest.py
+++ b/lib/topotest.py
@@ -560,6 +560,15 @@ class Router(Node):
                 logger.warning("LDP Test need Linux Kernel 4.5 minimum")
                 return "LDP Test need Linux Kernel 4.5 minimum"
 
+            # Check if required kernel modules are available with a dryrun modprobe
+            # Silent accept of modprobe command assumes ok status
+            if self.cmd('/sbin/modprobe -n mpls-router' ) != "":
+                logger.warning("LDP Test needs mpls-router kernel module")
+                return "LDP Test needs mpls-router kernel module"
+            if self.cmd('/sbin/modprobe -n mpls-iptunnel') != "":
+                logger.warning("LDP Test needs mpls-iptunnel kernel module")
+                return "LDP Test needs mpls-router kernel module"
+
             self.cmd('/sbin/modprobe mpls-router')
             self.cmd('/sbin/modprobe mpls-iptunnel')
             self.cmd('echo 100000 > /proc/sys/net/mpls/platform_labels')

--- a/ospf-topo1/test_ospf_topo1.py
+++ b/ospf-topo1/test_ospf_topo1.py
@@ -249,7 +249,6 @@ def test_ospf_json():
             'spfScheduleDelayMsecs': 0,
             'holdtimeMinMsecs': 50,
             'holdtimeMaxMsecs': 5000,
-            'spfLastDurationMsecs': 0,
             'lsaMinIntervalMsecs': 5000,
             'lsaMinArrivalMsecs': 1000,
             'writeMultiplier': 20,


### PR DESCRIPTION
- Remove a check for spf timer runtime in ospf test
- Disable LDP tests if required kernel modules are missing