### PR TITLE
ldp-topo1: Use 'label implicit-null' for implicit labels

### DIFF
--- a/ldp-topo1/r1/show_ipv4_route.ref
+++ b/ldp-topo1/r1/show_ipv4_route.ref
@@ -1,7 +1,7 @@
 O   1.1.1.1/32 [110/0] is directly connected, lo
-O>* 2.2.2.2/32 [110/10] via 10.0.1.2, r1-eth0, label y
+O>* 2.2.2.2/32 [110/10] via 10.0.1.2, r1-eth0, label implicit-null
 O>* 3.3.3.3/32 [110/20] via 10.0.1.2, r1-eth0, label xxx
 O>* 4.4.4.4/32 [110/20] via 10.0.1.2, r1-eth0, label xxx
 O   10.0.1.0/24 [110/10] is directly connected, r1-eth0
-O>* 10.0.2.0/24 [110/20] via 10.0.1.2, r1-eth0, label y
-O>* 10.0.3.0/24 [110/20] via 10.0.1.2, r1-eth0, label y
+O>* 10.0.2.0/24 [110/20] via 10.0.1.2, r1-eth0, label implicit-null
+O>* 10.0.3.0/24 [110/20] via 10.0.1.2, r1-eth0, label implicit-null

--- a/ldp-topo1/r2/show_ipv4_route.ref
+++ b/ldp-topo1/r2/show_ipv4_route.ref
@@ -1,7 +1,7 @@
-O>* 1.1.1.1/32 [110/10] via 10.0.1.1, r2-eth0, label y
+O>* 1.1.1.1/32 [110/10] via 10.0.1.1, r2-eth0, label implicit-null
 O   2.2.2.2/32 [110/0] is directly connected, lo
-O>* 3.3.3.3/32 [110/10] via 10.0.2.3, r2-eth1, label y
-O>* 4.4.4.4/32 [110/10] via 10.0.2.4, r2-eth1, label y
+O>* 3.3.3.3/32 [110/10] via 10.0.2.3, r2-eth1, label implicit-null
+O>* 4.4.4.4/32 [110/10] via 10.0.2.4, r2-eth1, label implicit-null
 O   10.0.1.0/24 [110/10] is directly connected, r2-eth0
 O   10.0.2.0/24 [110/10] is directly connected, r2-eth1
 O   10.0.3.0/24 [110/10] is directly connected, r2-eth2

--- a/ldp-topo1/r3/show_ipv4_route.ref
+++ b/ldp-topo1/r3/show_ipv4_route.ref
@@ -1,7 +1,7 @@
 O>* 1.1.1.1/32 [110/20] via 10.0.2.2, r3-eth0, label xxx
-O>* 2.2.2.2/32 [110/10] via 10.0.2.2, r3-eth0, label y
+O>* 2.2.2.2/32 [110/10] via 10.0.2.2, r3-eth0, label implicit-null
 O   3.3.3.3/32 [110/0] is directly connected, lo
-O>* 4.4.4.4/32 [110/10] via 10.0.2.4, r3-eth0, label y
-O>* 10.0.1.0/24 [110/20] via 10.0.2.2, r3-eth0, label y
+O>* 4.4.4.4/32 [110/10] via 10.0.2.4, r3-eth0, label implicit-null
+O>* 10.0.1.0/24 [110/20] via 10.0.2.2, r3-eth0, label implicit-null
 O   10.0.2.0/24 [110/10] is directly connected, r3-eth0
 O   10.0.3.0/24 [110/10] is directly connected, r3-eth1

--- a/ldp-topo1/r4/show_ipv4_route.ref
+++ b/ldp-topo1/r4/show_ipv4_route.ref
@@ -1,7 +1,7 @@
 O>* 1.1.1.1/32 [110/20] via 10.0.2.2, r4-eth0, label xxx
-O>* 2.2.2.2/32 [110/10] via 10.0.2.2, r4-eth0, label y
-O>* 3.3.3.3/32 [110/10] via 10.0.2.3, r4-eth0, label y
+O>* 2.2.2.2/32 [110/10] via 10.0.2.2, r4-eth0, label implicit-null
+O>* 3.3.3.3/32 [110/10] via 10.0.2.3, r4-eth0, label implicit-null
 O   4.4.4.4/32 [110/0] is directly connected, lo
-O>* 10.0.1.0/24 [110/20] via 10.0.2.2, r4-eth0, label y
+O>* 10.0.1.0/24 [110/20] via 10.0.2.2, r4-eth0, label implicit-null
 O   10.0.2.0/24 [110/10] is directly connected, r4-eth0
-O>* 10.0.3.0/24 [110/20] via 10.0.2.2, r4-eth0, label y
+O>* 10.0.3.0/24 [110/20] via 10.0.2.2, r4-eth0, label implicit-null

--- a/ldp-topo1/test_ldp_topo1.py
+++ b/ldp-topo1/test_ldp_topo1.py
@@ -553,11 +553,11 @@ def test_zebra_ipv4_routingTable():
             # Mask out label - all LDP labels should be >= 10 (2-digit)
             #   leaving the implicit labels unmasked
             actual = re.sub(r" label [0-9][0-9]+", " label xxx", actual)
-            #   and translating remaining implicit (single-digit) labels to label y
-            actual = re.sub(r" label [0-9]+", " label y", actual)
+            #   and translating remaining implicit (single-digit) labels to label implicit-null
+            actual = re.sub(r" label [0-9]+", " label implicit-null", actual)
             # Check if we have implicit labels - if not, then remove them from reference
-            if (not re.search(r" label y", actual)):
-		expected = re.sub(r", label y", "", expected)
+            if (not re.search(r" label implicit-null", actual)):
+                expected = re.sub(r", label implicit-null", "", expected)
 
             # now fix newlines of expected (make them all the same)
             expected = ('\n'.join(expected.splitlines()) + '\n').splitlines(1)


### PR DESCRIPTION
Signed-off-by: Martin Winter <mwinter@netdef.org>