### PR TITLE
Save diagnostics to log directory

### DIFF
--- a/lib/topogen.py
+++ b/lib/topogen.py
@@ -40,13 +40,13 @@ Basic usage instructions:
 
 import os
 import sys
+import logging
 import json
 import ConfigParser
 import glob
 import grp
 import platform
 import pwd
-import re
 import subprocess
 
 from mininet.net import Mininet
@@ -883,6 +883,15 @@ def diagnose_env():
     is ok, otherwise `False`.
     """
     ret = True
+
+    # Log diagnostics to file so it can be examined later.
+    fhandler = logging.FileHandler(filename='/tmp/topotests/diagnostics.txt')
+    fhandler.setLevel(logging.DEBUG)
+    fhandler.setFormatter(
+        logging.Formatter(fmt='%(asctime)s %(levelname)s: %(message)s')
+    )
+    logger.addHandler(fhandler)
+
     logger.info('Running environment diagnostics')
 
     # Load configuration
@@ -1005,5 +1014,8 @@ def diagnose_env():
     # pylint: disable=W0702
     except:
         logger.warning('failed to find exabgp or returned error')
+
+    # After we logged the output to file, remove the handler.
+    logger.removeHandler(fhandler)
 
     return ret

--- a/lib/topogen.py
+++ b/lib/topogen.py
@@ -955,6 +955,13 @@ def diagnose_env():
 
                 logger.warning('could not find {} in {}'.format(fname, frrdir))
                 ret = False
+            else:
+                if fname != 'zebra':
+                    continue
+
+                os.system(
+                    '{} -v 2>&1 >/tmp/topotests/frr_zebra.txt'.format(path)
+                )
 
     # Assert that Quagga utilities exist
     quaggadir = config.get('topogen', 'quaggadir')
@@ -987,6 +994,13 @@ def diagnose_env():
             if not os.path.isfile(path):
                 logger.warning('could not find {} in {}'.format(fname, quaggadir))
                 ret = False
+            else:
+                if fname != 'zebra':
+                    continue
+
+                os.system(
+                    '{} -v 2>&1 >/tmp/topotests/quagga_zebra.txt'.format(path)
+                )
 
     if not os.path.isdir('/tmp'):
         logger.warning('could not find /tmp for logs')

--- a/lib/topogen.py
+++ b/lib/topogen.py
@@ -884,13 +884,18 @@ def diagnose_env():
     """
     ret = True
 
-    # Log diagnostics to file so it can be examined later.
-    fhandler = logging.FileHandler(filename='/tmp/topotests/diagnostics.txt')
-    fhandler.setLevel(logging.DEBUG)
-    fhandler.setFormatter(
-        logging.Formatter(fmt='%(asctime)s %(levelname)s: %(message)s')
-    )
-    logger.addHandler(fhandler)
+    # Test log path exists before installing handler.
+    if not os.path.isdir('/tmp'):
+        logger.warning('could not find /tmp for logs')
+    else:
+        os.system('mkdir /tmp/topotests')
+        # Log diagnostics to file so it can be examined later.
+        fhandler = logging.FileHandler(filename='/tmp/topotests/diagnostics.txt')
+        fhandler.setLevel(logging.DEBUG)
+        fhandler.setFormatter(
+            logging.Formatter(fmt='%(asctime)s %(levelname)s: %(message)s')
+        )
+        logger.addHandler(fhandler)
 
     logger.info('Running environment diagnostics')
 
@@ -1001,9 +1006,6 @@ def diagnose_env():
                 os.system(
                     '{} -v 2>&1 >/tmp/topotests/quagga_zebra.txt'.format(path)
                 )
-
-    if not os.path.isdir('/tmp'):
-        logger.warning('could not find /tmp for logs')
 
     # Test MPLS availability
     krel = platform.release()


### PR DESCRIPTION
Save more information in log directory to help debugging issues later.

Extra: save the `zebra -v` output to catch misconfiguration.