### PR TITLE
all-protocol-startup/isis: Fix for PR 1176

### DIFF
--- a/all-protocol-startup/r1/show_isis_interface_detail.ref
+++ b/all-protocol-startup/r1/show_isis_interface_detail.ref
@@ -1,5 +1,5 @@
 Area test:
-  Interface: r1-eth5, State: Up, Active, Circuit Id: 0x1
+  Interface: r1-eth5, State: Up, Active, Circuit Id: 0xXX
     Type: lan, Level: L1, SNPA: XXXX.XXXX.XXXX
     Level-1 Information:
       Metric: 10, Active neighbors: 0
@@ -13,7 +13,7 @@ Area test:
     IPv6 Prefixes:
       fc00:0:0:5::1/64
 
-  Interface: r1-eth6, State: Up, Active, Circuit Id: 0x1
+  Interface: r1-eth6, State: Up, Active, Circuit Id: 0xXX
     Type: lan, Level: L2, SNPA: XXXX.XXXX.XXXX
     Level-2 Information:
       Metric: 10, Active neighbors: 0

--- a/all-protocol-startup/test_all_protocol_startup.py
+++ b/all-protocol-startup/test_all_protocol_startup.py
@@ -496,6 +496,8 @@ def test_isis_interfaces():
             actual = re.sub(r"fe80::[0-9a-f:]+", "fe80::XXXX:XXXX:XXXX:XXXX", actual)
             # Mask out SNPA mac address portion. They are random...
             actual = re.sub(r"SNPA: [0-9a-f\.]+", "SNPA: XXXX.XXXX.XXXX", actual)
+            # Mask out Circuit ID number
+            actual = re.sub(r"Circuit Id: 0x[0-9]+", "Circuit Id: 0xXX", actual)
             # Fix newlines (make them all the same)
             actual = ('\n'.join(actual.splitlines()) + '\n').splitlines(1)
 


### PR DESCRIPTION
Fix check for "show isis interface" to allow different circuit ids than 1