### PR TITLE
Improve JSON error output

### DIFF
--- a/lib/topogen.py
+++ b/lib/topogen.py
@@ -46,7 +46,6 @@ import glob
 import grp
 import platform
 import pwd
-import re
 import subprocess
 
 from mininet.net import Mininet

--- a/lib/topotest.py
+++ b/lib/topotest.py
@@ -198,20 +198,20 @@ def pid_exists(pid):
     else:
         return True
 
-def get_textdiff(text1, text2, title1="", title2=""):
+def get_textdiff(text1, text2, title1="", title2="", **opts):
     "Returns empty string if same or formatted diff"
 
     diff = '\n'.join(difflib.unified_diff(text1, text2,
-           fromfile=title1, tofile=title2))
+           fromfile=title1, tofile=title2, **opts))
     # Clean up line endings
     diff = os.linesep.join([s for s in diff.splitlines() if s])
     return diff
 
-def difflines(text1, text2, title1='', title2=''):
+def difflines(text1, text2, title1='', title2='', **opts):
     "Wrapper for get_textdiff to avoid string transformations."
     text1 = ('\n'.join(text1.rstrip().splitlines()) + '\n').splitlines(1)
     text2 = ('\n'.join(text2.rstrip().splitlines()) + '\n').splitlines(1)
-    return get_textdiff(text1, text2, title1, title2)
+    return get_textdiff(text1, text2, title1, title2, **opts)
 
 def get_file(content):
     """

--- a/lib/topotest.py
+++ b/lib/topotest.py
@@ -51,7 +51,8 @@ class json_cmp_result(object):
 
     def add_error(self, error):
         "Append error message to the result"
-        self.errors.append(error)
+        for line in error.splitlines():
+            self.errors.append(line)
 
     def has_errors(self):
         "Returns True if there were errors, otherwise False."

--- a/lib/topotest.py
+++ b/lib/topotest.py
@@ -58,7 +58,7 @@ class json_cmp_result(object):
         return len(self.errors) > 0
 
 
-def json_cmp(d1, d2, reason=False):
+def json_cmp(d1, d2):
     """
     JSON compare function. Receives two parameters:
     * `d1`: json value


### PR DESCRIPTION
Make the JSON failure message more straightforward by diffing the compared dictionaries and pointing out the differences.

Example output:
```
>           assert topotest.json_cmp(output, expected) is None, assertmsg
E           AssertionError: Zebra IPv4 Routing Table verification failed for router r1
E           assert json["192.168.1.0/24"] value is different (
E             --- Expected value
E             +++ Current value
E             @@ -3 +3 @@
E             -        "distance": 0, 
E             +        "distance": 90, 
E             @@ -8,0 +9 @@
E             +                "interfaceIndex": 2, 
E             @@ -20,0 +22 @@
E             +                "interfaceIndex": 2, )
E             json["192.168.3.0/24"] value is different (
E             --- Expected value
E             +++ Current value
E             @@ -3 +3 @@
E             -        "distance": 0, 
E             +        "distance": 90, 
E             @@ -9,0 +10 @@
E             +                "interfaceIndex": 3, )
E             json["193.1.1.0/26"] value is different (
E             --- Expected value
E             +++ Current value
E             @@ -3 +3 @@
E             -        "distance": 0, 
E             +        "distance": 90, 
E             @@ -8,0 +9 @@
E             +                "interfaceIndex": 3, 
E             @@ -20,0 +22 @@
E             +                "interfaceIndex": 3, )
E             json["193.1.2.0/24"] value is different (
E             --- Expected value
E             +++ Current value
E             @@ -3 +3 @@
E             -        "distance": 0, 
E             +        "distance": 90, 
E             @@ -9,0 +10 @@
E             +                "interfaceIndex": 3, )
```