### PR TITLE
eigrp-topo1: Remove check for EIGRP distance

### DIFF
--- a/eigrp-topo1/r1/show_ip_route.json_ref
+++ b/eigrp-topo1/r1/show_ip_route.json_ref
@@ -3,7 +3,6 @@
     {
       "prefix":"192.168.1.0/24",
       "protocol":"eigrp",
-      "distance":0,
       "metric":0,
       "nexthops":[
         {
@@ -32,7 +31,6 @@
       "prefix":"192.168.3.0/24",
       "protocol":"eigrp",
       "selected":true,
-      "distance":0,
       "metric":0,
       "nexthops":[
         {
@@ -49,7 +47,6 @@
     {
       "prefix":"193.1.1.0/26",
       "protocol":"eigrp",
-      "distance":0,
       "metric":0,
       "nexthops":[
         {
@@ -78,7 +75,6 @@
       "prefix":"193.1.2.0/24",
       "protocol":"eigrp",
       "selected":true,
-      "distance":0,
       "metric":0,
       "nexthops":[
         {

--- a/eigrp-topo1/r2/show_ip_route.json_ref
+++ b/eigrp-topo1/r2/show_ip_route.json_ref
@@ -4,7 +4,6 @@
       "prefix":"192.168.1.0/24",
       "protocol":"eigrp",
       "selected":true,
-      "distance":0,
       "metric":0,
       "nexthops":[
         {
@@ -22,7 +21,6 @@
       "prefix":"192.168.3.0/24",
       "protocol":"eigrp",
       "selected":true,
-      "distance":0,
       "metric":0,
       "nexthops":[
         {
@@ -39,7 +37,6 @@
     {
       "prefix":"193.1.1.0/26",
       "protocol":"eigrp",
-      "distance":0,
       "metric":0,
       "nexthops":[
         {
@@ -67,7 +64,6 @@
     {
       "prefix":"193.1.2.0/24",
       "protocol":"eigrp",
-      "distance":0,
       "metric":0,
       "nexthops":[
         {

--- a/eigrp-topo1/r3/show_ip_route.json_ref
+++ b/eigrp-topo1/r3/show_ip_route.json_ref
@@ -4,7 +4,6 @@
       "prefix":"192.168.1.0/24",
       "protocol":"eigrp",
       "selected":true,
-      "distance":0,
       "metric":0,
       "nexthops":[
         {
@@ -39,7 +38,6 @@
     {
       "prefix":"192.168.3.0/24",
       "protocol":"eigrp",
-      "distance":0,
       "metric":0,
       "nexthops":[
         {
@@ -68,7 +66,6 @@
       "prefix":"193.1.1.0/26",
       "protocol":"eigrp",
       "selected":true,
-      "distance":0,
       "metric":0,
       "nexthops":[
         {
@@ -85,7 +82,6 @@
     {
       "prefix":"193.1.2.0/24",
       "protocol":"eigrp",
-      "distance":0,
       "metric":0,
       "nexthops":[
         {


### PR DESCRIPTION
- Distance used to be wrong (0), new commit fixes this (90). To avoid breaking older outstanding Pull Requests, remove the distance check

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>