### PR TITLE
ldp-topo1: Remove check for protocol in installed LSPs

### DIFF
--- a/ldp-topo1/r1/ip_mpls_route.ref
+++ b/ldp-topo1/r1/ip_mpls_route.ref
@@ -1,5 +1,5 @@
-xx as to xx via inet 10.0.1.2 dev r1-eth0  proto zebra
-xx as to xx via inet 10.0.1.2 dev r1-eth0  proto zebra
-xx via inet 10.0.1.2 dev r1-eth0  proto zebra
-xx via inet 10.0.1.2 dev r1-eth0  proto zebra
-xx via inet 10.0.1.2 dev r1-eth0  proto zebra
+xx as to xx via inet 10.0.1.2 dev r1-eth0  proto xx
+xx as to xx via inet 10.0.1.2 dev r1-eth0  proto xx
+xx via inet 10.0.1.2 dev r1-eth0  proto xx
+xx via inet 10.0.1.2 dev r1-eth0  proto xx
+xx via inet 10.0.1.2 dev r1-eth0  proto xx

--- a/ldp-topo1/r1/ip_mpls_route.ref-1
+++ b/ldp-topo1/r1/ip_mpls_route.ref-1
@@ -1,5 +1,5 @@
-xx as to xx via inet 10.0.1.2 dev r1-eth0  proto zebra
-xx as to xx via inet 10.0.1.2 dev r1-eth0  proto zebra
-xx via inet 10.0.1.2 dev r1-eth0  proto zebra
-xx via inet 10.0.1.2 dev r1-eth0  proto zebra
-xx via inet 10.0.1.2 dev r1-eth0  proto zebra
+xx as to xx via inet 10.0.1.2 dev r1-eth0  proto xx
+xx as to xx via inet 10.0.1.2 dev r1-eth0  proto xx
+xx via inet 10.0.1.2 dev r1-eth0  proto xx
+xx via inet 10.0.1.2 dev r1-eth0  proto xx
+xx via inet 10.0.1.2 dev r1-eth0  proto xx

--- a/ldp-topo1/r2/ip_mpls_route.ref
+++ b/ldp-topo1/r2/ip_mpls_route.ref
@@ -1,5 +1,5 @@
-xx  proto zebra
+xx  proto xx
 	nexthopvia inet 10.0.2.3  dev r2-eth1 weight 1
 	nexthopvia inet 10.0.3.3  dev r2-eth2 weight 1
-xx via inet 10.0.1.1 dev r2-eth0  proto zebra
-xx via inet 10.0.2.4 dev r2-eth1  proto zebra
+xx via inet 10.0.1.1 dev r2-eth0  proto xx
+xx via inet 10.0.2.4 dev r2-eth1  proto xx

--- a/ldp-topo1/r2/ip_mpls_route.ref-1
+++ b/ldp-topo1/r2/ip_mpls_route.ref-1
@@ -1,5 +1,5 @@
-xx  proto zebra
+xx  proto xx
 	nexthopvia inet 10.0.2.3  dev r2-eth1 weight 1
 	nexthopvia inet 10.0.3.3  dev r2-eth2 weight 1
-xx via inet 10.0.1.1 dev r2-eth0  proto zebra
-xx via inet 10.0.2.4 dev r2-eth1  proto zebra
+xx via inet 10.0.1.1 dev r2-eth0  proto xx
+xx via inet 10.0.2.4 dev r2-eth1  proto xx

--- a/ldp-topo1/r3/ip_mpls_route.ref
+++ b/ldp-topo1/r3/ip_mpls_route.ref
@@ -1,10 +1,10 @@
-xx  proto zebra
+xx  proto xx
 	nexthopvia inet 10.0.2.2  dev r3-eth0 weight 1
 	nexthopvia inet 10.0.3.2  dev r3-eth1 weight 1
-xx  proto zebra
+xx  proto xx
 	nexthopvia inet 10.0.2.2  dev r3-eth0 weight 1
 	nexthopvia inet 10.0.3.2  dev r3-eth1 weight 1
-xx  proto zebra
+xx  proto xx
 	nexthopvia inet 10.0.2.2  dev r3-eth0 weight 1
 	nexthopvia inet 10.0.3.2  dev r3-eth1 weight 1
-xx via inet 10.0.2.4 dev r3-eth0  proto zebra
+xx via inet 10.0.2.4 dev r3-eth0  proto xx

--- a/ldp-topo1/r3/ip_mpls_route.ref-1
+++ b/ldp-topo1/r3/ip_mpls_route.ref-1
@@ -1,10 +1,10 @@
-xx  proto zebra
+xx  proto xx
 	nexthopvia inet 10.0.2.2  dev r3-eth0 weight 1
 	nexthopvia inet 10.0.3.2  dev r3-eth1 weight 1
-xx  proto zebra
+xx  proto xx
 	nexthopvia inet 10.0.2.2  dev r3-eth0 weight 1
 	nexthopvia inet 10.0.3.2  dev r3-eth1 weight 1
-xx  proto zebra
+xx  proto xx
 	nexthopvia inet 10.0.2.2  dev r3-eth0 weight 1
 	nexthopvia inet 10.0.3.2  dev r3-eth1 weight 1
-xx via inet 10.0.2.4 dev r3-eth0  proto zebra
+xx via inet 10.0.2.4 dev r3-eth0  proto xx

--- a/ldp-topo1/r4/ip_mpls_route.ref
+++ b/ldp-topo1/r4/ip_mpls_route.ref
@@ -1,7 +1,7 @@
-xx  proto zebra
+xx  proto xx
 	nexthopvia inet 10.0.2.2  dev r4-eth0 weight 1
 	nexthopvia inet 10.0.2.3  dev r4-eth0 weight 1
-xx as to xx via inet 10.0.2.2 dev r4-eth0  proto zebra
-xx via inet 10.0.2.2 dev r4-eth0  proto zebra
-xx via inet 10.0.2.2 dev r4-eth0  proto zebra
-xx via inet 10.0.2.3 dev r4-eth0  proto zebra
+xx as to xx via inet 10.0.2.2 dev r4-eth0  proto xx
+xx via inet 10.0.2.2 dev r4-eth0  proto xx
+xx via inet 10.0.2.2 dev r4-eth0  proto xx
+xx via inet 10.0.2.3 dev r4-eth0  proto xx

--- a/ldp-topo1/r4/ip_mpls_route.ref-1
+++ b/ldp-topo1/r4/ip_mpls_route.ref-1
@@ -1,7 +1,7 @@
-xx  proto zebra
+xx  proto xx
 	nexthopvia inet 10.0.2.2  dev r4-eth0 weight 1
 	nexthopvia inet 10.0.2.3  dev r4-eth0 weight 1
-xx as to xx via inet 10.0.2.2 dev r4-eth0  proto zebra
-xx via inet 10.0.2.2 dev r4-eth0  proto zebra
-xx via inet 10.0.2.2 dev r4-eth0  proto zebra
-xx via inet 10.0.2.3 dev r4-eth0  proto zebra
+xx as to xx via inet 10.0.2.2 dev r4-eth0  proto xx
+xx via inet 10.0.2.2 dev r4-eth0  proto xx
+xx via inet 10.0.2.2 dev r4-eth0  proto xx
+xx via inet 10.0.2.3 dev r4-eth0  proto xx

--- a/ldp-topo1/test_ldp_topo1.py
+++ b/ldp-topo1/test_ldp_topo1.py
@@ -688,9 +688,9 @@ def test_linux_mpls_routes():
             actual = net['r%s' % i].cmd('ip -family mpls route 2> /dev/null').rstrip()
              # Mask out label
             actual = re.sub(r"[0-9][0-9] via inet ", "xx via inet ", actual)
-            actual = re.sub(r"[0-9][0-9]  proto zebra", "xx  proto zebra", actual)
+            actual = re.sub(r"[0-9][0-9]  proto", "xx  proto", actual)
             actual = re.sub(r"[0-9][0-9] as to ", "xx as to ", actual)
-            actual = re.sub(r"proto zebra ", "proto zebra", actual)
+            actual = re.sub(r"proto \w+", "proto xx", actual)
  
             # Fix newlines (make them all the same)
             actual = ('\n'.join(actual.splitlines()) + '\n').splitlines(1)


### PR DESCRIPTION
PR #1213 in FRR changed the protocol of installed LSPs. To avoid breaking
older outstanding Pull Requests, remove the protocol check.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>