### PR TITLE
Fix eigrp topology results to be in new order.

### DIFF
--- a/eigrp-topo1/r1/show_ip_eigrp.ref
+++ b/eigrp-topo1/r1/show_ip_eigrp.ref
@@ -4,11 +4,12 @@ EIGRP Topology Table for AS(1)/ID(193.1.1.1)
 Codes: P - Passive, A - Active, U - Update, Q - Query, R - Reply
        r - reply Status, s - sia Status
 
-P  193.1.1.0/26, 1 successors, FD is 28160, serno: 0 
-       via Connected, r1-eth1
 P  192.168.1.0/24, 1 successors, FD is 28160, serno: 0 
        via Connected, r1-eth0
-P  193.1.2.0/24, 1 successors, FD is 30720, serno: 0 
-       via 193.1.1.2 (30720/28160), r1-eth1
 P  192.168.3.0/24, 1 successors, FD is 33280, serno: 0 
        via 193.1.1.2 (33280/30720), r1-eth1
+P  193.1.1.0/26, 1 successors, FD is 28160, serno: 0 
+       via Connected, r1-eth1
+P  193.1.2.0/24, 1 successors, FD is 30720, serno: 0 
+       via 193.1.1.2 (30720/28160), r1-eth1  
+

--- a/eigrp-topo1/r2/show_ip_eigrp.ref
+++ b/eigrp-topo1/r2/show_ip_eigrp.ref
@@ -4,11 +4,11 @@ EIGRP Topology Table for AS(1)/ID(193.1.2.1)
 Codes: P - Passive, A - Active, U - Update, Q - Query, R - Reply
        r - reply Status, s - sia Status
 
-P  193.1.1.0/26, 1 successors, FD is 28160, serno: 0 
-       via Connected, r2-eth0
 P  192.168.1.0/24, 1 successors, FD is 30720, serno: 0 
        via 193.1.1.1 (30720/28160), r2-eth0
-P  193.1.2.0/24, 1 successors, FD is 28160, serno: 0 
-       via Connected, r2-eth1
 P  192.168.3.0/24, 1 successors, FD is 30720, serno: 0 
        via 193.1.2.2 (30720/28160), r2-eth1
+P  193.1.1.0/26, 1 successors, FD is 28160, serno: 0 
+       via Connected, r2-eth0
+P  193.1.2.0/24, 1 successors, FD is 28160, serno: 0 
+       via Connected, r2-eth1

--- a/eigrp-topo1/r3/show_ip_eigrp.ref
+++ b/eigrp-topo1/r3/show_ip_eigrp.ref
@@ -4,11 +4,12 @@ EIGRP Topology Table for AS(1)/ID(193.1.2.2)
 Codes: P - Passive, A - Active, U - Update, Q - Query, R - Reply
        r - reply Status, s - sia Status
 
-P  193.1.1.0/26, 1 successors, FD is 30720, serno: 0 
-       via 193.1.2.1 (30720/28160), r3-eth1
 P  192.168.1.0/24, 1 successors, FD is 33280, serno: 0 
        via 193.1.2.1 (33280/30720), r3-eth1
-P  193.1.2.0/24, 1 successors, FD is 28160, serno: 0 
-       via Connected, r3-eth1
 P  192.168.3.0/24, 1 successors, FD is 28160, serno: 0 
        via Connected, r3-eth0
+P  193.1.1.0/26, 1 successors, FD is 30720, serno: 0 
+       via 193.1.2.1 (30720/28160), r3-eth1
+P  193.1.2.0/24, 1 successors, FD is 28160, serno: 0 
+       via Connected, r3-eth1
+


### PR DESCRIPTION
Switch from a linked list to a table changes
the order of output of a `show ip eigrp topo`

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>