### PR TITLE
Solve EIGRP topo output ordering problem

### DIFF
--- a/eigrp-topo1/r1/show_ip_eigrp.json
+++ b/eigrp-topo1/r1/show_ip_eigrp.json
@@ -1,0 +1,32 @@
+{
+    "P": {
+        "192.168.1.0/24": {
+            "fd": "28160",
+            "interface": " r1-eth0",
+            "serno": "0",
+            "successors": "1",
+            "via": "Connected"
+        },
+        "192.168.3.0/24": {
+            "fd": "33280",
+            "interface": " r1-eth1",
+            "serno": "0",
+            "successors": "1",
+            "via": "193.1.1.2 (33280/30720)"
+        },
+        "193.1.1.0/26": {
+            "fd": "28160",
+            "interface": " r1-eth1",
+            "serno": "0",
+            "successors": "1",
+            "via": "Connected"
+        },
+        "193.1.2.0/24": {
+            "fd": "30720",
+            "interface": " r1-eth1",
+            "serno": "0",
+            "successors": "1",
+            "via": "193.1.1.2 (30720/28160)"
+        }
+    }
+}

--- a/eigrp-topo1/r2/show_ip_eigrp.json
+++ b/eigrp-topo1/r2/show_ip_eigrp.json
@@ -1,0 +1,32 @@
+{
+    "P": {
+        "192.168.1.0/24": {
+            "fd": "30720",
+            "interface": " r2-eth0",
+            "serno": "0",
+            "successors": "1",
+            "via": "193.1.1.1 (30720/28160)"
+        },
+        "192.168.3.0/24": {
+            "fd": "30720",
+            "interface": " r2-eth1",
+            "serno": "0",
+            "successors": "1",
+            "via": "193.1.2.2 (30720/28160)"
+        },
+        "193.1.1.0/26": {
+            "fd": "28160",
+            "interface": " r2-eth0",
+            "serno": "0",
+            "successors": "1",
+            "via": "Connected"
+        },
+        "193.1.2.0/24": {
+            "fd": "28160",
+            "interface": " r2-eth1",
+            "serno": "0",
+            "successors": "1",
+            "via": "Connected"
+        }
+    }
+}

--- a/eigrp-topo1/r3/show_ip_eigrp.json
+++ b/eigrp-topo1/r3/show_ip_eigrp.json
@@ -1,0 +1,32 @@
+{
+    "P": {
+        "192.168.1.0/24": {
+            "fd": "33280",
+            "interface": " r3-eth1",
+            "serno": "0",
+            "successors": "1",
+            "via": "193.1.2.1 (33280/30720)"
+        },
+        "192.168.3.0/24": {
+            "fd": "28160",
+            "interface": " r3-eth0",
+            "serno": "0",
+            "successors": "1",
+            "via": "Connected"
+        },
+        "193.1.1.0/26": {
+            "fd": "30720",
+            "interface": " r3-eth1",
+            "serno": "0",
+            "successors": "1",
+            "via": "193.1.2.1 (30720/28160)"
+        },
+        "193.1.2.0/24": {
+            "fd": "28160",
+            "interface": " r3-eth1",
+            "serno": "0",
+            "successors": "1",
+            "via": "Connected"
+        }
+    }
+}


### PR DESCRIPTION
Transform 'show ip eigrp topo' output into data structures and compare using json_cmp() to avoid expecting output order.

This is a more definite solution for the problem solution proposed here: https://github.com/FRRouting/topotests/pull/37

Since we have the output in this format now, feel free to remove fields from comparison to avoid more false-positives.