### PR TITLE
Fix output to allow it on generic Debian

### DIFF
--- a/ldp-topo1/test_ldp_topo1.py
+++ b/ldp-topo1/test_ldp_topo1.py
@@ -690,7 +690,7 @@ def test_linux_mpls_routes():
             actual = re.sub(r"[0-9][0-9] via inet ", "xx via inet ", actual)
             actual = re.sub(r"[0-9][0-9]  proto", "xx  proto", actual)
             actual = re.sub(r"[0-9][0-9] as to ", "xx as to ", actual)
-            actual = re.sub(r"proto \w+", "proto xx", actual)
+            actual = re.sub(r"[ ]+proto \w+", "  proto xx", actual)
  
             # Fix newlines (make them all the same)
             actual = ('\n'.join(actual.splitlines()) + '\n').splitlines(1)

--- a/ospf6-topo1/test_ospf6_topo1.py
+++ b/ospf6-topo1/test_ospf6_topo1.py
@@ -332,7 +332,7 @@ def test_linux_ipv6_kernel_routingTable():
             for ll in linklocals:
                 actual = actual.replace(ll[1], "fe80::__(%s)__" % ll[0])
             # Mask out protocol name or number
-            actual = re.sub(r" proto [0-9a-z]+ ", " proto XXXX ", actual)
+            actual = re.sub(r"[ ]+proto [0-9a-z]+ ", "  proto XXXX ", actual)
             # Remove ff00::/8 routes (seen on some kernels - not from FRR)
             actual = re.sub(r'ff00::/8.*', '', actual)
 


### PR DESCRIPTION
- Generic Debian only has a single space in front of “proto” in the linux shell routing outptu

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>