### PR TITLE
ldp-vpls-topo1: Allow ospf neighbor json command with list (new) and dict (old)

### DIFF
--- a/ldp-vpls-topo1/r1/show_ip_ospf_neighbor.ref
+++ b/ldp-vpls-topo1/r1/show_ip_ospf_neighbor.ref
@@ -1,14 +1,18 @@
 {
-  "2.2.2.2":{
-    "priority":1,
-    "state":"Full/DR",
-    "address":"10.0.1.2",
-    "ifaceName":"r1-eth1:10.0.1.1"
-  },
-  "3.3.3.3":{
-    "priority":1,
-    "state":"Full/DR",
-    "address":"10.0.2.3",
-    "ifaceName":"r1-eth2:10.0.2.1"
-  }
+  "2.2.2.2":[
+    {
+      "priority":1,
+      "state":"Full/DR",
+      "address":"10.0.1.2",
+      "ifaceName":"r1-eth1:10.0.1.1"
+    }
+  ],
+  "3.3.3.3":[
+    {
+      "priority":1,
+      "state":"Full/DR",
+      "address":"10.0.2.3",
+      "ifaceName":"r1-eth2:10.0.2.1"
+    }
+  ]
 }

--- a/ldp-vpls-topo1/r1/show_ip_ospf_neighbor.ref-old-nolist
+++ b/ldp-vpls-topo1/r1/show_ip_ospf_neighbor.ref-old-nolist
@@ -1,0 +1,14 @@
+{
+  "2.2.2.2":{
+    "priority":1,
+    "state":"Full/DR",
+    "address":"10.0.1.2",
+    "ifaceName":"r1-eth1:10.0.1.1"
+  },
+  "3.3.3.3":{
+    "priority":1,
+    "state":"Full/DR",
+    "address":"10.0.2.3",
+    "ifaceName":"r1-eth2:10.0.2.1"
+  }
+}

--- a/ldp-vpls-topo1/r2/show_ip_ospf_neighbor.ref
+++ b/ldp-vpls-topo1/r2/show_ip_ospf_neighbor.ref
@@ -1,14 +1,18 @@
 {
-  "1.1.1.1":{
-    "priority":1,
-    "state":"Full/Backup",
-    "address":"10.0.1.1",
-    "ifaceName":"r2-eth1:10.0.1.2"
-  },
-  "3.3.3.3":{
-    "priority":1,
-    "state":"Full/DR",
-    "address":"10.0.3.3",
-    "ifaceName":"r2-eth2:10.0.3.2"
-  }
+  "1.1.1.1":[
+    {
+      "priority":1,
+      "state":"Full/Backup",
+      "address":"10.0.1.1",
+      "ifaceName":"r2-eth1:10.0.1.2"
+    }
+  ],
+  "3.3.3.3":[
+    {
+      "priority":1,
+      "state":"Full/DR",
+      "address":"10.0.3.3",
+      "ifaceName":"r2-eth2:10.0.3.2"
+    }
+  ]
 }

--- a/ldp-vpls-topo1/r2/show_ip_ospf_neighbor.ref-old-nolist
+++ b/ldp-vpls-topo1/r2/show_ip_ospf_neighbor.ref-old-nolist
@@ -1,0 +1,14 @@
+{
+  "1.1.1.1":{
+    "priority":1,
+    "state":"Full/Backup",
+    "address":"10.0.1.1",
+    "ifaceName":"r2-eth1:10.0.1.2"
+  },
+  "3.3.3.3":{
+    "priority":1,
+    "state":"Full/DR",
+    "address":"10.0.3.3",
+    "ifaceName":"r2-eth2:10.0.3.2"
+  }
+}

--- a/ldp-vpls-topo1/r3/show_ip_ospf_neighbor.ref
+++ b/ldp-vpls-topo1/r3/show_ip_ospf_neighbor.ref
@@ -1,14 +1,18 @@
 {
-  "1.1.1.1":{
-    "priority":1,
-    "state":"Full/Backup",
-    "address":"10.0.2.1",
-    "ifaceName":"r3-eth1:10.0.2.3"
-  },
-  "2.2.2.2":{
-    "priority":1,
-    "state":"Full/Backup",
-    "address":"10.0.3.2",
-    "ifaceName":"r3-eth2:10.0.3.3"
-  }
+  "1.1.1.1":[
+    {
+      "priority":1,
+      "state":"Full/Backup",
+      "address":"10.0.2.1",
+      "ifaceName":"r3-eth1:10.0.2.3"
+    }
+  ],
+  "2.2.2.2":[
+    {
+      "priority":1,
+      "state":"Full/Backup",
+      "address":"10.0.3.2",
+      "ifaceName":"r3-eth2:10.0.3.3"
+    }
+  ]
 }

--- a/ldp-vpls-topo1/r3/show_ip_ospf_neighbor.ref-old-nolist
+++ b/ldp-vpls-topo1/r3/show_ip_ospf_neighbor.ref-old-nolist
@@ -1,0 +1,14 @@
+{
+  "1.1.1.1":{
+    "priority":1,
+    "state":"Full/Backup",
+    "address":"10.0.2.1",
+    "ifaceName":"r3-eth1:10.0.2.3"
+  },
+  "2.2.2.2":{
+    "priority":1,
+    "state":"Full/Backup",
+    "address":"10.0.3.2",
+    "ifaceName":"r3-eth2:10.0.3.3"
+  }
+}

--- a/ldp-vpls-topo1/test_ldp_vpls_topo1.py
+++ b/ldp-vpls-topo1/test_ldp_vpls_topo1.py
@@ -180,8 +180,19 @@ def test_ospf_convergence():
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
 
+    # Old output (before FRR PR1383) didn't show a list of neighbors.
+    # Check for dict object and compare to old output if this is the case
+    tgen = get_topogen()
+    router = tgen.gears['r1']
+    output = router.vtysh_cmd("show ip ospf neighbor json", isjson=True)
+
+    if isinstance(output["2.2.2.2"], dict):
+        reffile = "show_ip_ospf_neighbor.ref-old-nolist"
+    else:
+        reffile = "show_ip_ospf_neighbor.ref"
+
     for rname in ['r1', 'r2', 'r3']:
-        router_compare_json_output(rname, "show ip ospf neighbor json", "show_ip_ospf_neighbor.ref")
+        router_compare_json_output(rname, "show ip ospf neighbor json", reffile)
 
 def test_rib():
     logger.info("Test: verify RIB")


### PR DESCRIPTION
Adjust format to new version as introduced by FRR PR 1383

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>