### PR TITLE
topotest: fix a regression in version_cmp

### DIFF
--- a/lib/test/test_version.py
+++ b/lib/test/test_version.py
@@ -78,3 +78,10 @@ def test_invalid_versions():
         assert version_cmp(curver, badver2)
         assert version_cmp(curver, badver3)
         assert version_cmp(curver, badver4)
+
+def test_regression_1():
+    """
+    Test regression on the following type of comparison: '3.0.2' > '3'
+    Expected result is 1.
+    """
+    assert version_cmp('3.0.2', '3') == 1

--- a/lib/topotest.py
+++ b/lib/topotest.py
@@ -291,7 +291,7 @@ def version_cmp(v1, v2):
             while v1g:
                 v1n = int(v1g.pop())
                 if v1n > 0:
-                    return -1
+                    return 1
             break
 
         if v1n > v2n:


### PR DESCRIPTION
It was found a regression on an edge case when the second number in the
comparison was (at least) 2 numbers longer the comparison would fail
with a wrong return value. It succeeded for some cases because the
first comparison in the exception was correct, but not the second.