### PR TITLE
topogen: import pytest assert function

### DIFF
--- a/lib/topogen.py
+++ b/lib/topogen.py
@@ -48,6 +48,7 @@ import grp
 import platform
 import pwd
 import subprocess
+import pytest
 
 from mininet.net import Mininet
 from mininet.log import setLogLevel

--- a/lib/topogen.py
+++ b/lib/topogen.py
@@ -386,7 +386,7 @@ class Topogen(object):
 
         if errors != '':
             self.set_error(errors, 'router_error')
-            assert errors != '', errors
+            assert False, errors
             return True
         return False
 


### PR DESCRIPTION
Use the pytest assert function to be able to report to pytest failures
that happened inside the API.

Signed-off-by: Rafael Zalamena <rzalamena@opensourcerouting.org>