### PR TITLE
bgp_l3vpn_to_bgp_vrf: skip test on arm processors with kernel's older than 4.11

### DIFF
--- a/bgp_l3vpn_to_bgp_vrf/customize.py
+++ b/bgp_l3vpn_to_bgp_vrf/customize.py
@@ -110,6 +110,11 @@ class ThisTestTopo(Topo):
         if tgen.hasmpls != True:
             logger.info('MPLS not available, tests will be skipped')
             return
+        mach = platform.machine()
+        krel = platform.release()
+        if mach[:1] == 'a' and topotest.version_cmp(krel, '4.11') < 0:
+            logger.info('Need Kernel version 4.11 to run on arm processor')
+            return
         for routern in range(2, 5):
             tgen.add_router('r{}'.format(routern))
         # Create CE routers
@@ -185,6 +190,10 @@ def ltemplatePreRouterStartHook():
     #check for mpls
     if tgen.hasmpls != True:
         logger.info('MPLS not available, skipping setup')
+        return
+    #check for normal init
+    if len(tgen.net) == 1:
+        logger.info('Topology not configured, skipping setup')
         return
     #collect/log info on iproute2
     cc.doCmd(tgen, 'r2', 'apt-cache policy iproute2')

--- a/bgp_l3vpn_to_bgp_vrf/customize.py
+++ b/bgp_l3vpn_to_bgp_vrf/customize.py
@@ -94,6 +94,7 @@ CWD = os.path.dirname(os.path.realpath(__file__))
 TEST = os.path.basename(CWD)
 
 InitSuccess = False
+iproute2Ver = None
 
 class ThisTestTopo(Topo):
     "Test topology builder"
@@ -196,10 +197,12 @@ def ltemplatePreRouterStartHook():
         logger.info('Topology not configured, skipping setup')
         return
     #collect/log info on iproute2
-    cc.doCmd(tgen, 'r2', 'apt-cache policy iproute2')
-    cc.doCmd(tgen, 'r2', 'yum info iproute2')
-    cc.doCmd(tgen, 'r2', 'yum info iproute')
-
+    found = cc.doCmd(tgen, 'r2', 'apt-cache policy iproute2', 'Installed: ([\d\.]*)')
+    if found != None:
+        global iproute2Ver
+        iproute2Ver = found.group(1)
+        logger.info('Have iproute2 version=' + iproute2Ver)
+    #trace errors/unexpected output
     cc.resetCounts()
     #configure r2 mpls interfaces
     intfs = ['lo', 'r2-eth0', 'r2-eth1', 'r2-eth2']
@@ -248,36 +251,40 @@ def ltemplatePostRouterStartHook():
     logger.info('post router-start hook')
     return;
 
-def versionCheck(vstr, rname='r1', compstr='<',cli=False, kernel='4.9'):
+def versionCheck(vstr, rname='r1', compstr='<',cli=False, kernel='4.9', iproute2=None):
     tgen = get_topogen()
-
     router = tgen.gears[rname]
+
+    if cli:
+        logger.info('calling mininet CLI')
+        tgen.mininet_cli()
+        logger.info('exited mininet CLI')
+
+    if InitSuccess != True:
+        ret = 'Test not initialized'
+        return ret
 
     if tgen.hasmpls != True:
         ret = 'MPLS not initialized'
         return ret
 
-    if InitSuccess != True:
-        ret = 'Test not successfully initialized'
-        return ret
+    if kernel != None:
+        krel = platform.release()
+        if topotest.version_cmp(krel, kernel) < 0:
+            ret = 'Skipping tests, old kernel ({} < {})'.format(krel, kernel)
+            return ret
+
+    if iproute2 != None:
+        if iproute2Ver == None or topotest.version_cmp(iproute2Ver, iproute2) < 0:
+            ret = 'Skipping tests, old iproute2 ({} < {})'.format(iproute2Ver, iproute2)
+            return ret
 
     ret = True
     try:
         if router.has_version(compstr, vstr):
-            ret = False
-            logger.debug('version check failed, version {} {}'.format(compstr, vstr))
+            ret = 'Skipping tests, old FRR version {} {}'.format(compstr, vstr)
+            return ret
     except:
         ret = True
-    if ret == False:
-        ret = 'Skipping tests on old version ({}{})'.format(compstr, vstr)
-        logger.info(ret)
-    elif kernel != None:
-        krel = platform.release()
-        if topotest.version_cmp(krel, kernel) < 0:
-            ret = 'Skipping tests on old version ({} < {})'.format(krel, kernel)
-            logger.info(ret)
-    if cli:
-        logger.info('calling mininet CLI')
-        tgen.mininet_cli()
-        logger.info('exited mininet CLI')
+
     return ret

--- a/bgp_l3vpn_to_bgp_vrf/scripts/adjacencies.py
+++ b/bgp_l3vpn_to_bgp_vrf/scripts/adjacencies.py
@@ -1,8 +1,4 @@
 from lutil import luCommand
-luCommand('ce1','ping 192.168.1.1 -c 1',' 0. packet loss','pass','CE->PE ping')
-luCommand('ce2','ping 192.168.1.1 -c 1',' 0. packet loss','pass','CE->PE ping')
-luCommand('ce3','ping 192.168.1.1 -c 1',' 0. packet loss','pass','CE->PE ping')
-luCommand('ce4','ping 192.168.2.1 -c 1',' 0. packet loss','pass','CE->PE ping')
 luCommand('ce1','vtysh -c "show bgp summary"',' 00:0','wait','Adjacencies up',180)
 luCommand('ce2','vtysh -c "show bgp summary"',' 00:0','wait','Adjacencies up')
 luCommand('ce3','vtysh -c "show bgp summary"',' 00:0','wait','Adjacencies up')

--- a/bgp_l3vpn_to_bgp_vrf/scripts/check_linux_mpls.py
+++ b/bgp_l3vpn_to_bgp_vrf/scripts/check_linux_mpls.py
@@ -1,19 +1,7 @@
 from lutil import luCommand, luLast
 from lib import topotest
-from lib.topolog import logger
-minver = '4.9'
-ret = luCommand('r1','apt-cache policy iproute2', 'Installed: ([\d\.]*)')
+ret = luCommand('r2','ip -M route show','\d*(?= via inet 10.0.2.4 dev r2-eth1)','wait','See mpls route to r4')
 found = luLast()
-dotest = -1
-if ret != False and found != None:
-    dotest = topotest.version_cmp(found.group(1), minver)
-if dotest == -1:
-    luCommand('r1','apt-cache policy iproute2', '.', 'pass', 'Skipping test, iproute2 version {} < {}'.format(found.group(1), minver))
-    ret = False
-else:
-    logger.info('iproute2 ver = {} dotest = {}'.format(found.group(1), dotest))
-    ret = luCommand('r2','ip -M route show','\d*(?= via inet 10.0.2.4 dev r2-eth1)','wait','See mpls route to r4')
-    found = luLast()
 if ret != False and found != None:
     label4r4 = found.group(0)
     luCommand('r2','ip -M route show','.','pass','See %s as label to r4' % label4r4)

--- a/bgp_l3vpn_to_bgp_vrf/scripts/check_linux_vrf.py
+++ b/bgp_l3vpn_to_bgp_vrf/scripts/check_linux_vrf.py
@@ -1,0 +1,14 @@
+from lutil import luCommand
+rtrs = ['r1', 'r3', 'r4']
+for rtr in rtrs:
+    luCommand(rtr, 'ip link show type vrf {}-cust1'.format(rtr),'cust1: .*UP,LOWER_UP','pass','VRF cust1 up')
+    luCommand(rtr, 'ip add show vrf {}-cust1'.format(rtr),'r..eth4: .*UP,LOWER_UP.* 192.168','pass','VRF cust1 IP config')
+    luCommand(rtr, 'ip route show vrf {}-cust1'.format(rtr),'192.168...0/24 dev r.-eth','pass','VRF cust1 interface route')
+luCommand('r4', 'ip link show type vrf r4-cust2','cust2: .*UP,LOWER_UP','pass','VRF cust2 up')
+luCommand('r4', 'ip add show vrf r4-cust2','r..eth5.*UP,LOWER_UP.* 192.168','pass','VRF cust1 IP config')
+luCommand(rtr, 'ip route show vrf r4-cust2'.format(rtr),'192.168...0/24 dev r.-eth','pass','VRF cust2 interface route')
+rtrs = ['ce1', 'ce2', 'ce3']
+for rtr in rtrs:
+    luCommand(rtr, 'ip route show','192.168...0/24 dev ce.-eth0','pass','CE interface route')
+    luCommand(rtr,'ping 192.168.1.1 -c 1',' 0. packet loss','wait','CE->PE ping')
+luCommand('ce4','ping 192.168.2.1 -c 1',' 0. packet loss','wait','CE4->PE4 ping')

--- a/bgp_l3vpn_to_bgp_vrf/test_bgp_l3vpn_to_bgp_vrf.py
+++ b/bgp_l3vpn_to_bgp_vrf/test_bgp_l3vpn_to_bgp_vrf.py
@@ -29,6 +29,15 @@ sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../')
 
 from lib.ltemplate import *
 
+def test_check_linux_vrf():
+    CliOnFail = None
+    # For debugging, uncomment the next line
+    #CliOnFail = 'tgen.mininet_cli'
+    CheckFunc = 'customize.versionCheck(\'3.1\')'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'customize.versionCheck(\'3.1\', cli=True)'
+    ltemplateTest('scripts/check_linux_vrf.py', False, CliOnFail, CheckFunc)
+
 def test_adjacencies():
     CliOnFail = None
     # For debugging, uncomment the next line

--- a/bgp_l3vpn_to_bgp_vrf/test_bgp_l3vpn_to_bgp_vrf.py
+++ b/bgp_l3vpn_to_bgp_vrf/test_bgp_l3vpn_to_bgp_vrf.py
@@ -33,9 +33,9 @@ def test_check_linux_vrf():
     CliOnFail = None
     # For debugging, uncomment the next line
     #CliOnFail = 'tgen.mininet_cli'
-    CheckFunc = 'customize.versionCheck(\'3.1\')'
+    CheckFunc = 'customize.versionCheck(\'3.1\', iproute2=\'4.9\')'
     #uncomment next line to start cli *before* script is run
-    #CheckFunc = 'customize.versionCheck(\'3.1\', cli=True)'
+    #CheckFunc = 'customize.versionCheck(\'3.1\', cli=True, iproute2=\'4.9\')'
     ltemplateTest('scripts/check_linux_vrf.py', False, CliOnFail, CheckFunc)
 
 def test_adjacencies():
@@ -70,9 +70,9 @@ def test_check_linux_mpls():
     CliOnFail = None
     # For debugging, uncomment the next line
     #CliOnFail = 'tgen.mininet_cli'
-    CheckFunc = 'customize.versionCheck(\'3.1\')'
+    CheckFunc = 'customize.versionCheck(\'3.1\', iproute2=\'4.9\')'
     #uncomment next line to start cli *before* script is run
-    #CheckFunc = 'customize.versionCheck(\'3.1\', cli=True)'
+    #CheckFunc = 'customize.versionCheck(\'3.1\', cli=True, iproute2=\'4.9\')'
     ltemplateTest('scripts/check_linux_mpls.py', False, CliOnFail, CheckFunc)
 
 def SKIP_test_cleanup_all():


### PR DESCRIPTION
arm 7 currently skipped due to missing mpls modules, arm8 fails with 4.9 kernel.