### PR TITLE
ldp-vpls-topo1: support new OSPF JSON format

### DIFF
--- a/ldp-vpls-topo1/r1/show_ip_ospf_neighbor.json
+++ b/ldp-vpls-topo1/r1/show_ip_ospf_neighbor.json
@@ -1,0 +1,26 @@
+{
+  "neighbors": {
+    "2.2.2.2": [
+      {
+        "dbSummaryCounter": 0,
+        "retransmitCounter": 0,
+        "priority": 1,
+        "state": "Full/DR",
+        "address": "10.0.1.2",
+        "ifaceName": "r1-eth1:10.0.1.1",
+        "requestCounter": 0
+      }
+    ],
+    "3.3.3.3": [
+      {
+        "dbSummaryCounter": 0,
+        "retransmitCounter": 0,
+        "priority": 1,
+        "state": "Full/DR",
+        "address": "10.0.2.3",
+        "ifaceName": "r1-eth2:10.0.2.1",
+        "requestCounter": 0
+      }
+    ]
+  }
+}

--- a/ldp-vpls-topo1/r2/show_ip_ospf_neighbor.json
+++ b/ldp-vpls-topo1/r2/show_ip_ospf_neighbor.json
@@ -1,0 +1,26 @@
+{
+  "neighbors": {
+    "1.1.1.1": [
+      {
+        "priority":1,
+        "state":"Full/Backup",
+        "address":"10.0.1.1",
+        "ifaceName":"r2-eth1:10.0.1.2",
+        "retransmitCounter":0,
+        "requestCounter":0,
+        "dbSummaryCounter":0
+      }
+    ],
+    "3.3.3.3": [
+      {
+        "priority":1,
+        "state":"Full/DR",
+        "address":"10.0.3.3",
+        "ifaceName":"r2-eth2:10.0.3.2",
+        "retransmitCounter":0,
+        "requestCounter":0,
+        "dbSummaryCounter":0
+      }
+    ]
+  }
+}

--- a/ldp-vpls-topo1/r3/show_ip_ospf_neighbor.json
+++ b/ldp-vpls-topo1/r3/show_ip_ospf_neighbor.json
@@ -1,0 +1,26 @@
+{
+  "neighbors": {
+    "1.1.1.1": [
+      {
+        "priority":1,
+        "state":"Full/Backup",
+        "address":"10.0.2.1",
+        "ifaceName":"r3-eth1:10.0.2.3",
+        "retransmitCounter":0,
+        "requestCounter":0,
+        "dbSummaryCounter":0
+      }
+    ],
+    "2.2.2.2": [
+      {
+        "priority":1,
+        "state":"Full/Backup",
+        "address":"10.0.3.2",
+        "ifaceName":"r3-eth2:10.0.3.3",
+        "retransmitCounter":0,
+        "requestCounter":0,
+        "dbSummaryCounter":0
+      }
+    ]
+  }
+}

--- a/ldp-vpls-topo1/test_ldp_vpls_topo1.py
+++ b/ldp-vpls-topo1/test_ldp_vpls_topo1.py
@@ -189,13 +189,18 @@ def test_ospf_convergence():
     # We could have either old format (without "neighbors" and direct list
     # of IP's or new format from PR1659 with "neighbors".
     # Trying old formats first and fall back to new format
-    try:
+    #
+    # New format: neighbors have dict instead of list of dicts (PR1723).
+    if output.has_key('neighbors'):
+        if isinstance(output['neighbors'], dict):
+            reffile = "show_ip_ospf_neighbor.json"
+        else:
+            reffile = "show_ip_ospf_neighbor.ref"
+    else:
         if isinstance(output["2.2.2.2"], dict):
             reffile = "show_ip_ospf_neighbor.ref-old-nolist"
         else:
             reffile = "show_ip_ospf_neighbor.ref-no-neigh"
-    except:
-        reffile = "show_ip_ospf_neighbor.ref"
 
     for rname in ['r1', 'r2', 'r3']:
         router_compare_json_output(rname, "show ip ospf neighbor json", reffile)


### PR DESCRIPTION
Support the new OSPF JSON output format for `show ip ospf neighbor
json` introduced in FRR's PR 1723.

Signed-off-by: Rafael Zalamena <rzalamena@opensourcerouting.org>

Reference: https://github.com/FRRouting/frr/pull/1723