### PR TITLE
bgp_vrf_netns: do not run test on 32 bit linux machines

### DIFF
--- a/bgp_vrf_netns/test_bgp_vrf_netns_topo.py
+++ b/bgp_vrf_netns/test_bgp_vrf_netns_topo.py
@@ -195,7 +195,7 @@ def test_bgp_convergence():
         output = router.vtysh_cmd('show bgp vrf r1-cust1 summary json', isjson=True)
         return topotest.json_cmp(output, expected)
 
-    _, res = topotest.run_and_expect(_convergence_test, None, count=90, wait=1)
+    _, res = topotest.run_and_expect(_convergence_test, None, count=120, wait=1)
     assertmsg = 'BGP router network did not converge'
     assert res is None, assertmsg
 

--- a/bgp_vrf_netns/test_bgp_vrf_netns_topo.py
+++ b/bgp_vrf_netns/test_bgp_vrf_netns_topo.py
@@ -97,6 +97,10 @@ def setup_module(module):
             return  pytest.skip('Skipping BGP VRF NETNS Test. VRF NETNS backend not available on FRR')
         if os.system('ip netns list') != 0:
             return  pytest.skip('Skipping BGP VRF NETNS Test. NETNS not available on System')
+        osbased = router.run('uname -m').rstrip()
+        osrestriction = ['i686','i386']
+        if osbased in osrestriction:
+            return  pytest.skip('Skipping BGP VRF NETNS Test. NETNS not available on 32 bit machines')
     # retrieve VRF backend kind
     if CustomizeVrfWithNetns == True:
         logger.info('Testing with VRF Namespace support')


### PR DESCRIPTION
It seems vrf netns is not working on 32 bit platforms.
For that, the test should be cancelled.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>