### PR TITLE
bgp_l3vpn_to_bgp_vrf: use FRR PR #2053

### DIFF
--- a/bgp_l3vpn_to_bgp_vrf/scripts/check_linux_mpls.py
+++ b/bgp_l3vpn_to_bgp_vrf/scripts/check_linux_mpls.py
@@ -1,42 +1,42 @@
 from lutil import luCommand, luLast
 from lib import topotest
-ret = luCommand('r2','ip -M route show','\d*(?= via inet 10.0.2.4 dev r2-eth1)','wait','See mpls route to r4')
+
+ret = luCommand('r2', 'ip -M route show',
+	'\d*(?= via inet 10.0.2.4 dev r2-eth1)','wait','See mpls route to r4')
 found = luLast()
+
 if ret != False and found != None:
     label4r4 = found.group(0)
-    luCommand('r2','ip -M route show','.','pass','See %s as label to r4' % label4r4)
-    ret = luCommand('r2','ip -M route show','\d*(?= via inet 10.0.1.1 dev r2-eth0)','wait','See mpls route to r1')
+    luCommand('r2', 'ip -M route show',
+	'.', 'pass',
+	'See %s as label to r4' % label4r4)
+    ret = luCommand('r2', 'ip -M route show',
+	'\d*(?= via inet 10.0.1.1 dev r2-eth0)', 'wait',
+	'See mpls route to r1')
     found = luLast()
+
 if ret != False and found != None:
     label4r1 = found.group(0)
-    luCommand('r2','ip -M route show','.','pass','See %s as label to r1' % label4r1)
-#    luCommand('ce4','ip route add default via 192.168.2.1')
-#    luCommand('ce1','ip route add default via 192.168.1.1')
-#    luCommand('r1','ip route add 99.0.0.1 vrf r1-cust1 dev r1-eth4 via 192.168.1.2')
-#    luCommand('r4','ip route add 99.0.0.4 vrf r4-cust2 dev r4-eth5 via 192.168.2.2')
+    luCommand('r2', 'ip -M route show',
+	'.', 'pass', 'See %s as label to r1' % label4r1)
 
+    luCommand('r1', 'ip route show vrf r1-cust1',
+	'99.0.0.4', 'pass', 'VRF->MPLS PHP route installed')
+    luCommand('r4', 'ip route show vrf r4-cust2',
+	'99.0.0.1','pass', 'VRF->MPLS PHP route installed')
 
-#    luCommand('r1','ip -M route add 101 dev r1-cust1')
-#    luCommand('r4','ip -M route add 104 dev r4-cust2')
+    luCommand('r1', 'ip -M route show', '101','MPLS->VRF route installed')
+    luCommand('r4', 'ip -M route show', '104','MPLS->VRF route installed')
 
-#    luCommand('r1','ip route add 99.0.0.4/32 vrf r1-cust1 nexthop encap mpls %s/104 via 10.0.1.2 dev r1-eth0'%label4r4)
-#    luCommand('r4','ip route add 99.0.0.1/32 vrf r4-cust2 nexthop encap mpls %s/101 via 10.0.2.2 dev r4-eth0'%label4r1)
+    luCommand('ce1', 'ping 99.0.0.4 -I 99.0.0.1 -c 1',
+	' 0. packet loss','wait','CE->CE (loopback) ping - l3vpn+zebra case')
+    luCommand('ce4', 'ping 99.0.0.1 -I 99.0.0.4 -c 1',
+	' 0. packet loss','wait','CE->CE (loopback) ping - l3vpn+zebra case')
 
-    luCommand('r1','ip route show vrf r1-cust1','99.0.0.4','pass', 'VRF->MPLS PHP route installed')
-    luCommand('r4','ip route show vrf r4-cust2','99.0.0.1','pass', 'VRF->MPLS PHP route installed')
-    luCommand('r1','ip -M route show','101','MPLS->VRF route installed')
-    luCommand('r4','ip -M route show','104','MPLS->VRF route installed')
-    luCommand('ce1','ping 99.0.0.4 -I 99.0.0.1 -c 1',' 0. packet loss','wait','CE->CE (loopback) ping - l3vpn+zebra case')
-    luCommand('ce4','ping 99.0.0.1 -I 99.0.0.4 -c 1',' 0. packet loss','wait','CE->CE (loopback) ping - l3vpn+zebra case')
-#    luCommand('r1','ip route del 99.0.0.4/32 vrf r1-cust1')
-#    luCommand('r4','ip route del 99.0.0.1/32 vrf r4-cust2')
-#    luCommand('r1','ip route add 99.0.0.4/32 vrf r1-cust1 nexthop encap mpls %s/1004/104 via 10.0.1.2 dev r1-eth0'%label4r4)
-#    luCommand('r4','ip -M route add 1004 dev lo')
-#    luCommand('r4','ip route add 99.0.0.1/32 vrf r4-cust2 nexthop encap mpls %s/1001/101 via 10.0.2.2 dev r4-eth0'%label4r1)
-#    luCommand('r1','ip -M route add 1001 dev lo')
-#    luCommand('r1','ip route show vrf r1-cust1','99.0.0.4.*1004/104','pass', 'VRF->MPLS non-PHP route installed')
-#    luCommand('r4','ip route show vrf r4-cust2','99.0.0.1.*1001/101','pass', 'VRF->MPLS non-PHP route installed')
-    luCommand('r1','ip -M route show','1001','MPLS "non-PHP" route installed')
-    luCommand('r4','ip -M route show','1004','MPLS "non-PHP" route installed')
-    luCommand('ce1','ping 99.0.0.4 -I 99.0.0.1 -c 1',' 0. packet loss','wait','CE->CE (loopback) ping')
-    luCommand('ce4','ping 99.0.0.1 -I 99.0.0.4 -c 1',' 0. packet loss','wait','CE->CE (loopback) ping')
+    luCommand('r1', 'ip -M route show', '1001','MPLS "non-PHP" route installed')
+    luCommand('r4', 'ip -M route show', '1004','MPLS "non-PHP" route installed')
+
+    luCommand('ce1', 'ping 99.0.0.4 -I 99.0.0.1 -c 1',
+	' 0. packet loss','wait','CE->CE (loopback) ping')
+    luCommand('ce4', 'ping 99.0.0.1 -I 99.0.0.4 -c 1',
+	' 0. packet loss','wait','CE->CE (loopback) ping')

--- a/bgp_l3vpn_to_bgp_vrf/scripts/check_routes.py
+++ b/bgp_l3vpn_to_bgp_vrf/scripts/check_routes.py
@@ -288,20 +288,28 @@ want = [
 ]
 bgpribRequireUnicastRoutes('ce2','ipv4','','Cust 1 routes from remote',want)
 
-# Requires bvl-bug-degenerate-no-label fix
-# want = [
-#     {'p':'5.1.0.0/24', 'n':'192.168.1.1'},
-#     {'p':'5.1.1.0/24', 'n':'192.168.1.1'},
-#     {'p':'5.4.2.0/24', 'n':'192.168.1.1'},
-#     {'p':'5.4.3.0/24', 'n':'192.168.1.1'},
-# ]
-# bgpribRequireUnicastRoutes('ce3','ipv4','','Cust 1 routes from remote',want)
-# 
-# want = [
-#     {'p':'5.1.0.0/24', 'n':'192.168.2.1'},
-#     {'p':'5.1.1.0/24', 'n':'192.168.2.1'},
-#     {'p':'5.1.2.0/24', 'n':'192.168.2.1'},
-#     {'p':'5.1.3.0/24', 'n':'192.168.2.1'},
-# ]
-# bgpribRequireUnicastRoutes('ce4','ipv4','','Cust 2 routes from remote',want)
+# human readable output for debugging
+luCommand('r4','vtysh -c "show bgp vrf r4-cust1 ipv4 uni"')
+luCommand('r4','vtysh -c "show bgp vrf r4-cust2 ipv4 uni"')
+luCommand('r4','vtysh -c "show bgp ipv4 vpn"')
+luCommand('r4','vtysh -c "show ip route vrf r4-cust1"')
+luCommand('r4','vtysh -c "show ip route vrf r4-cust2"')
+
+
+# Requires bvl-bug-degenerate-no-label fix (FRR PR #2053)
+want = [
+    {'p':'5.1.0.0/24', 'n':'192.168.1.1'},
+    {'p':'5.1.1.0/24', 'n':'192.168.1.1'},
+    {'p':'5.4.2.0/24', 'n':'192.168.1.1'},
+    {'p':'5.4.3.0/24', 'n':'192.168.1.1'},
+]
+bgpribRequireUnicastRoutes('ce3','ipv4','','Cust 1 routes from remote',want)
+
+want = [
+    {'p':'5.1.0.0/24', 'n':'192.168.2.1'},
+    {'p':'5.1.1.0/24', 'n':'192.168.2.1'},
+    {'p':'5.1.2.0/24', 'n':'192.168.2.1'},
+    {'p':'5.1.3.0/24', 'n':'192.168.2.1'},
+]
+bgpribRequireUnicastRoutes('ce4','ipv4','','Cust 2 routes from remote',want)
 


### PR DESCRIPTION
Check CE routes from CE in another VRF attached to same PE router. Relies
on FRR bug fix to not require labeled nexthop for paths that go only
through PE router and not mpls core.