### PR TITLE
Topotests misc improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .cache
 __pycache__
 *.pyc
+.pytest_cache

--- a/isis-topo1/r1/r1_topology.json
+++ b/isis-topo1/r1/r1_topology.json
@@ -76,7 +76,6 @@
         },
         {
           "interface": "r3",
-          "metric": "internal",
           "next-hop": "10",
           "parent": "r1-eth0",
           "type": "IP6",
@@ -84,7 +83,6 @@
         },
         {
           "interface": "r3",
-          "metric": "internal",
           "next-hop": "10",
           "parent": "r1-eth0",
           "type": "IP6",

--- a/isis-topo1/r2/r2_topology.json
+++ b/isis-topo1/r2/r2_topology.json
@@ -76,7 +76,6 @@
         },
         {
           "interface": "r4",
-          "metric": "internal",
           "next-hop": "10",
           "parent": "r2-eth0",
           "type": "IP6",
@@ -84,7 +83,6 @@
         },
         {
           "interface": "r4",
-          "metric": "internal",
           "next-hop": "10",
           "parent": "r2-eth0",
           "type": "IP6",

--- a/isis-topo1/r3/r3_topology.json
+++ b/isis-topo1/r3/r3_topology.json
@@ -47,15 +47,6 @@
           "interface": "r3-eth1",
           "metric": "20",
           "next-hop": "r5",
-          "parent": "r5(4)",
-          "type": "pseudo_TE-IS",
-          "vertex": "r5"
-        },
-        {
-          "interface": "r3-eth1",
-          "metric": "20",
-          "next-hop": "r5",
-          "parent": "r5(2)",
           "type": "TE-IS",
           "vertex": "r4"
         },
@@ -114,15 +105,6 @@
           "interface": "r3-eth1",
           "metric": "20",
           "next-hop": "r5",
-          "parent": "r5(4)",
-          "type": "pseudo_TE-IS",
-          "vertex": "r5"
-        },
-        {
-          "interface": "r3-eth1",
-          "metric": "20",
-          "next-hop": "r5",
-          "parent": "r5(2)",
           "type": "TE-IS",
           "vertex": "r4"
         },

--- a/isis-topo1/r3/r3_topology.json
+++ b/isis-topo1/r3/r3_topology.json
@@ -75,7 +75,7 @@
           "metric": "internal",
           "parent": "0",
           "type": "IP6",
-          "vertex": "2001:db8:1:1::/64"
+          "vertex": "2001:db8:2:1::/64"
         },
         {
           "interface": "r3-eth1",
@@ -87,15 +87,13 @@
         },
         {
           "interface": "r5",
-          "metric": "internal",
           "next-hop": "10",
           "parent": "r3-eth1",
           "type": "IP6",
-          "vertex": "2001:db8:1:2::/64"
+          "vertex": "2001:db8:2:2::/64"
         },
         {
           "interface": "r5",
-          "metric": "internal",
           "next-hop": "10",
           "parent": "r3-eth1",
           "type": "IP6",
@@ -110,15 +108,13 @@
         },
         {
           "interface": "r5",
-          "metric": "internal",
           "next-hop": "20",
           "parent": "r3-eth1",
           "type": "IP6",
-          "vertex": "2001:db8:2:2::/64"
+          "vertex": "2001:db8:1:2::/64"
         },
         {
           "interface": "r5",
-          "metric": "internal",
           "next-hop": "20",
           "parent": "r3-eth1",
           "type": "IP6",
@@ -170,7 +166,7 @@
           "metric": "internal",
           "parent": "0",
           "type": "IP6",
-          "vertex": "2001:db8:2:1::/64"
+          "vertex": "2001:db8:1:1::/64"
         },
         {
           "interface": "r3-eth0",
@@ -182,15 +178,6 @@
         },
         {
           "interface": "r1",
-          "metric": "internal",
-          "next-hop": "10",
-          "parent": "r3-eth0",
-          "type": "IP6",
-          "vertex": "2001:db8:1:1::/64"
-        },
-        {
-          "interface": "r1",
-          "metric": "internal",
           "next-hop": "10",
           "parent": "r3-eth0",
           "type": "IP6",

--- a/isis-topo1/r4/r4_topology.json
+++ b/isis-topo1/r4/r4_topology.json
@@ -47,23 +47,6 @@
           "interface": "r4-eth1",
           "metric": "20",
           "next-hop": "r5",
-          "parent": "r5(4)",
-          "type": "pseudo_TE-IS",
-          "vertex": "r3"
-        },
-        {
-          "interface": "r4-eth1",
-          "metric": "20",
-          "next-hop": "r5",
-          "parent": "r5(4)",
-          "type": "pseudo_TE-IS",
-          "vertex": "r5"
-        },
-        {
-          "interface": "r4-eth1",
-          "metric": "20",
-          "next-hop": "r5",
-          "parent": "r3(2)",
           "type": "TE-IS",
           "vertex": "r3"
         },
@@ -122,23 +105,6 @@
           "interface": "r4-eth1",
           "metric": "20",
           "next-hop": "r5",
-          "parent": "r5(4)",
-          "type": "pseudo_TE-IS",
-          "vertex": "r3"
-        },
-        {
-          "interface": "r4-eth1",
-          "metric": "20",
-          "next-hop": "r5",
-          "parent": "r5(4)",
-          "type": "pseudo_TE-IS",
-          "vertex": "r5"
-        },
-        {
-          "interface": "r4-eth1",
-          "metric": "20",
-          "next-hop": "r5",
-          "parent": "r3(2)",
           "type": "TE-IS",
           "vertex": "r3"
         },
@@ -194,14 +160,6 @@
           "parent": "r4-eth0",
           "type": "IP",
           "vertex": "10.254.0.2/32"
-        },
-        {
-          "interface": "r4-eth0",
-          "metric": "20",
-          "next-hop": "r2",
-          "parent": "r2(4)",
-          "type": "pseudo_TE-IS",
-          "vertex": "r2"
         }
       ],
       "ipv6": [
@@ -229,14 +187,6 @@
           "parent": "r4-eth0",
           "type": "IP6",
           "vertex": "2001:db8:f::2/128"
-        },
-        {
-          "interface": "r4-eth0",
-          "metric": "20",
-          "next-hop": "r2",
-          "parent": "r2(4)",
-          "type": "pseudo_TE-IS",
-          "vertex": "r2"
         }
       ]
     }

--- a/isis-topo1/r4/r4_topology.json
+++ b/isis-topo1/r4/r4_topology.json
@@ -87,7 +87,6 @@
         },
         {
           "interface": "r5",
-          "metric": "internal",
           "next-hop": "10",
           "parent": "r4-eth1",
           "type": "IP6",
@@ -95,7 +94,6 @@
         },
         {
           "interface": "r5",
-          "metric": "internal",
           "next-hop": "10",
           "parent": "r4-eth1",
           "type": "IP6",
@@ -110,15 +108,13 @@
         },
         {
           "interface": "r5",
-          "metric": "internal",
           "next-hop": "20",
           "parent": "r4-eth1",
           "type": "IP6",
-          "vertex": "2001:db8:2:1::/64"
+          "vertex": "2001:db8:1:1::/64"
         },
         {
           "interface": "r5",
-          "metric": "internal",
           "next-hop": "20",
           "parent": "r4-eth1",
           "type": "IP6",
@@ -182,7 +178,6 @@
         },
         {
           "interface": "r2",
-          "metric": "internal",
           "next-hop": "10",
           "parent": "r4-eth0",
           "type": "IP6",

--- a/isis-topo1/r5/r5_topology.json
+++ b/isis-topo1/r5/r5_topology.json
@@ -80,14 +80,6 @@
           "parent": "r5-eth1",
           "type": "IP",
           "vertex": "10.254.0.4/32"
-        },
-        {
-          "interface": "r5-eth0",
-          "metric": "20",
-          "next-hop": "r3",
-          "parent": "r3(4)",
-          "type": "pseudo_TE-IS",
-          "vertex": "r3"
         }
       ],
       "ipv6": [
@@ -153,14 +145,6 @@
           "parent": "r5-eth1",
           "type": "IP6",
           "vertex": "2001:db8:f::4/128"
-        },
-        {
-          "interface": "r5-eth0",
-          "metric": "20",
-          "next-hop": "r3",
-          "parent": "r3(4)",
-          "type": "pseudo_TE-IS",
-          "vertex": "r3"
         }
       ]
     },

--- a/isis-topo1/r5/r5_topology.json
+++ b/isis-topo1/r5/r5_topology.json
@@ -90,13 +90,13 @@
           "metric": "internal",
           "parent": "0",
           "type": "IP6",
-          "vertex": "2001:db8:1:1::/64"
+          "vertex": "2001:db8:2:1::/64"
         },
         {
           "metric": "internal",
           "parent": "0",
           "type": "IP6",
-          "vertex": "2001:db8:1:2::/64"
+          "vertex": "2001:db8:2:2::/64"
         },
         {
           "interface": "r5-eth0",
@@ -116,15 +116,13 @@
         },
         {
           "interface": "r3",
-          "metric": "internal",
           "next-hop": "10",
           "parent": "r5-eth0",
           "type": "IP6",
-          "vertex": "2001:db8:2:1::/64"
+          "vertex": "2001:db8:1:1::/64"
         },
         {
           "interface": "r3",
-          "metric": "internal",
           "next-hop": "10",
           "parent": "r5-eth0",
           "type": "IP6",
@@ -132,15 +130,13 @@
         },
         {
           "interface": "r4",
-          "metric": "internal",
           "next-hop": "10",
           "parent": "r5-eth1",
           "type": "IP6",
-          "vertex": "2001:db8:2:2::/64"
+          "vertex": "2001:db8:1:2::/64"
         },
         {
           "interface": "r4",
-          "metric": "internal",
           "next-hop": "10",
           "parent": "r5-eth1",
           "type": "IP6",

--- a/isis-topo1/test_isis_topo1.py
+++ b/isis-topo1/test_isis_topo1.py
@@ -341,6 +341,15 @@ def parse_topology(lines, level):
         item_match = re.match(
             r"([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+)", line)
         if item_match is not None:
+            # Skip header
+            if (item_match.group(1) == 'Vertex' and
+                item_match.group(2) == 'Type' and
+                item_match.group(3) == 'Metric' and
+                item_match.group(4) == 'Next-Hop' and
+                item_match.group(5) == 'Interface' and
+                item_match.group(6) == 'Parent'):
+                continue
+
             areas[area][level][ipv].append({
                 'vertex': item_match.group(1),
                 'type': item_match.group(2),

--- a/lib/test/test_json.py
+++ b/lib/test/test_json.py
@@ -329,5 +329,128 @@ def test_json_with_list_failure():
     assert json_cmp(dcomplete, dsub2) is not None
     assert json_cmp(dcomplete, dsub3) is not None
 
+
+def test_json_list_start_success():
+    "Test JSON encoded data that starts with a list that should succeed."
+
+    dcomplete = [
+        {
+            "id": 100,
+            "value": "abc",
+        },
+        {
+            "id": 200,
+            "value": "abcd",
+        },
+        {
+            "id": 300,
+            "value": "abcde",
+        },
+    ]
+
+    dsub1 = [
+        {
+            "id": 100,
+            "value": "abc",
+        }
+    ]
+
+    dsub2 = [
+        {
+            "id": 100,
+            "value": "abc",
+        },
+        {
+            "id": 200,
+            "value": "abcd",
+        }
+    ]
+
+    dsub3 = [
+        {
+            "id": 300,
+            "value": "abcde",
+        }
+    ]
+
+    dsub4 = [
+    ]
+
+    dsub5 = [
+        {
+            "id": 100,
+        }
+    ]
+
+    assert json_cmp(dcomplete, dsub1) is None
+    assert json_cmp(dcomplete, dsub2) is None
+    assert json_cmp(dcomplete, dsub3) is None
+    assert json_cmp(dcomplete, dsub4) is None
+    assert json_cmp(dcomplete, dsub5) is None
+
+
+def test_json_list_start_failure():
+    "Test JSON encoded data that starts with a list that should fail."
+
+    dcomplete = [
+        {
+            "id": 100,
+            "value": "abc"
+        },
+        {
+            "id": 200,
+            "value": "abcd"
+        },
+        {
+            "id": 300,
+            "value": "abcde"
+        },
+    ]
+
+    dsub1 = [
+        {
+            "id": 100,
+            "value": "abcd",
+        }
+    ]
+
+    dsub2 = [
+        {
+            "id": 100,
+            "value": "abc",
+        },
+        {
+            "id": 200,
+            "value": "abc",
+        }
+    ]
+
+    dsub3 = [
+        {
+            "id": 100,
+            "value": "abc",
+        },
+        {
+            "id": 350,
+            "value": "abcde",
+        }
+    ]
+
+    dsub4 = [
+        {
+            "value": "abcx",
+        },
+        {
+            "id": 300,
+            "value": "abcde",
+        }
+    ]
+
+    assert json_cmp(dcomplete, dsub1) is not None
+    assert json_cmp(dcomplete, dsub2) is not None
+    assert json_cmp(dcomplete, dsub3) is not None
+    assert json_cmp(dcomplete, dsub4) is not None
+
+
 if __name__ == '__main__':
     sys.exit(pytest.main())

--- a/lib/topogen.py
+++ b/lib/topogen.py
@@ -132,9 +132,9 @@ class Topogen(object):
 
         # Test for MPLS Kernel modules available
         self.hasmpls = False
-        if os.system('/sbin/modprobe mpls-router') != 0:
+        if not topotest.module_present('mpls-router'):
             logger.info('MPLS tests will not run (missing mpls-router kernel module)')
-        elif os.system('/sbin/modprobe mpls-iptunnel') != 0:
+        elif not topotest.module_present('mpls-iptunnel'):
             logger.info('MPLS tests will not run (missing mpls-iptunnel kernel module)')
         else:
             self.hasmpls = True
@@ -1039,9 +1039,9 @@ def diagnose_env():
         logger.info('LDPd tests will not run (have kernel "{}", but it requires 4.5)'.format(krel))
 
     # Test for MPLS Kernel modules available
-    if os.system('/sbin/modprobe -n mpls-router') != 0:
+    if not topotest.module_present('mpls-router', load=False) != 0:
         logger.info('LDPd tests will not run (missing mpls-router kernel module)')
-    if os.system('/sbin/modprobe -n mpls-iptunnel') != 0:
+    if not topotest.module_present('mpls-iptunnel', load=False) != 0:
         logger.info('LDPd tests will not run (missing mpls-iptunnel kernel module)')
 
     # TODO remove me when we start supporting exabgp >= 4

--- a/lib/topotest.py
+++ b/lib/topotest.py
@@ -118,8 +118,6 @@ def _json_list_cmp(list1, list2, parent, result):
                 matched = True
                 break
 
-        if matched:
-            break
         if not matched:
             unmatched.append(expected)
 

--- a/lib/topotest.py
+++ b/lib/topotest.py
@@ -89,6 +89,47 @@ def json_diff(d1, d2):
     dstr2 = json.dumps(d2, **json_format_opts)
     return difflines(dstr2, dstr1, title1='Expected value', title2='Current value', n=0)
 
+
+def _json_list_cmp(list1, list2, parent, result):
+    "Handles list type entries."
+    # Check second list2 type
+    if not isinstance(list1, type([])) or not isinstance(list2, type([])):
+        result.add_error(
+            '{} has different type than expected '.format(parent) +
+            '(have {}, expected {}):\n{}'.format(
+                type(list1), type(list2), json_diff(list1, list2)))
+        return
+
+    # Check list size
+    if len(list2) > len(list1):
+        result.add_error(
+            '{} too few items '.format(parent) +
+            '(have {}, expected {}:\n {})'.format(
+                len(list1), len(list2),
+                json_diff(list1, list2)))
+        return
+
+    # List all unmatched items errors
+    unmatched = []
+    for expected in list2:
+        matched = False
+        for value in list1:
+            if json_cmp({'json': value}, {'json': expected}) is None:
+                matched = True
+                break
+
+        if matched:
+            break
+        if not matched:
+            unmatched.append(expected)
+
+    # If there are unmatched items, error out.
+    if unmatched:
+        result.add_error(
+            '{} value is different (\n{})'.format(
+                parent, json_diff(list1, list2)))
+
+
 def json_cmp(d1, d2):
     """
     JSON compare function. Receives two parameters:
@@ -102,11 +143,20 @@ def json_cmp(d1, d2):
     """
     squeue = [(d1, d2, 'json')]
     result = json_cmp_result()
+
     for s in squeue:
         nd1, nd2, parent = s
-        s1, s2 = set(nd1), set(nd2)
+
+        # Handle JSON beginning with lists.
+        if isinstance(nd1, type([])) or isinstance(nd2, type([])):
+            _json_list_cmp(nd1, nd2, parent, result)
+            if result.has_errors():
+                return result
+            else:
+                return None
 
         # Expect all required fields to exist.
+        s1, s2 = set(nd1), set(nd2)
         s2_req = set([key for key in nd2 if nd2[key] is not None])
         diff = s2_req - s1
         if diff != set({}):
@@ -119,6 +169,7 @@ def json_cmp(d1, d2):
                 result.add_error('"{}" should not exist in {} (have {}):\n{}'.format(
                     key, parent, str(s1), json_diff(nd1[key], nd2[key])))
                 continue
+
             # If nd1 key is a dict, we have to recurse in it later.
             if isinstance(nd2[key], type({})):
                 if not isinstance(nd1[key], type({})):
@@ -130,42 +181,10 @@ def json_cmp(d1, d2):
                 nparent = '{}["{}"]'.format(parent, key)
                 squeue.append((nd1[key], nd2[key], nparent))
                 continue
+
             # Check list items
             if isinstance(nd2[key], type([])):
-                if not isinstance(nd1[key], type([])):
-                    result.add_error(
-                        '{}["{}"] has different type than expected '.format(parent, key) +
-                        '(have {}, expected {}):\n{}'.format(
-                            type(nd1[key]), type(nd2[key]), json_diff(nd1[key], nd2[key])))
-                    continue
-                # Check list size
-                if len(nd2[key]) > len(nd1[key]):
-                    result.add_error(
-                        '{}["{}"] too few items '.format(parent, key) +
-                        '(have {}, expected {}:\n {})'.format(
-                            len(nd1[key]), len(nd2[key]),
-                            json_diff(nd1[key], nd2[key])))
-                    continue
-
-                # List all unmatched items errors
-                unmatched = []
-                for expected in nd2[key]:
-                    matched = False
-                    for value in nd1[key]:
-                        if json_cmp({'json': value}, {'json': expected}) is None:
-                            matched = True
-                            break
-
-                    if matched:
-                        break
-                    if not matched:
-                        unmatched.append(expected)
-
-                # If there are unmatched items, error out.
-                if unmatched:
-                    result.add_error(
-                        '{}["{}"] value is different (\n{})'.format(
-                            parent, key, json_diff(nd1[key], nd2[key])))
+                _json_list_cmp(nd1[key], nd2[key], parent, result)
                 continue
 
             # Compare JSON values
@@ -179,6 +198,7 @@ def json_cmp(d1, d2):
         return result
 
     return None
+
 
 def run_and_expect(func, what, count=20, wait=3):
     """


### PR DESCRIPTION
This PR bring some topotests improvements, like:

* Do a proper module check (helps running topotests in `docker`);
* Ignore new py.test temporary files/directories;
* Make `json_cmp` more flexible by allowing JSON data that begin with a list;