### PR TITLE
isis-topo1: make isis topology match .dot file

### DIFF
--- a/isis-topo1/r3/r3_route6.json
+++ b/isis-topo1/r3/r3_route6.json
@@ -1,27 +1,13 @@
 {
   "2001:db8:1:1::/64": [
     {
-      "distance": 115,
-      "metric": 10,
-      "nexthops": [
-        {
-          "active": true,
-          "afi": "ipv6",
-          "interfaceIndex": 2,
-          "interfaceName": "r3-eth0"
-        }
-      ],
-      "prefix": "2001:db8:1:1::/64",
-      "protocol": "isis"
-    },
-    {
       "nexthops": [
         {
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 3,
-          "interfaceName": "r3-eth1"
+          "interfaceIndex": 2,
+          "interfaceName": "r3-eth0"
         }
       ],
       "prefix": "2001:db8:1:1::/64",
@@ -32,7 +18,7 @@
   "2001:db8:1:2::/64": [
     {
       "distance": 115,
-      "metric": 10,
+      "metric": 20,
       "nexthops": [
         {
           "active": true,
@@ -54,8 +40,8 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 2,
-          "interfaceName": "r3-eth0"
+          "interfaceIndex": 3,
+          "interfaceName": "r3-eth1"
         }
       ],
       "prefix": "2001:db8:2:1::/64",
@@ -66,7 +52,7 @@
   "2001:db8:2:2::/64": [
     {
       "distance": 115,
-      "metric": 20,
+      "metric": 10,
       "nexthops": [
         {
           "active": true,

--- a/isis-topo1/r3/zebra.conf
+++ b/isis-topo1/r3/zebra.conf
@@ -1,11 +1,11 @@
 hostname r3
 interface r3-eth0
  ip address 10.0.20.1/24
- ipv6 address 2001:db8:2:1::1/64
+ ipv6 address 2001:db8:1:1::1/64
 !
 interface r3-eth1
  ip address 10.0.10.2/24
- ipv6 address 2001:db8:1:1::2/64
+ ipv6 address 2001:db8:2:1::2/64
 !
 interface lo
  ip address 10.254.0.3/32

--- a/isis-topo1/r4/r4_route6.json
+++ b/isis-topo1/r4/r4_route6.json
@@ -2,7 +2,7 @@
   "2001:db8:1:1::/64": [
     {
       "distance": 115,
-      "metric": 10,
+      "metric": 20,
       "nexthops": [
         {
           "active": true,
@@ -18,20 +18,6 @@
     }
   ],
   "2001:db8:1:2::/64": [
-    {
-      "distance": 115,
-      "metric": 10,
-      "nexthops": [
-        {
-          "active": true,
-          "afi": "ipv6",
-          "interfaceIndex": 3,
-          "interfaceName": "r4-eth1"
-        }
-      ],
-      "prefix": "2001:db8:1:2::/64",
-      "protocol": "isis"
-    },
     {
       "nexthops": [
         {
@@ -50,7 +36,7 @@
   "2001:db8:2:1::/64": [
     {
       "distance": 115,
-      "metric": 20,
+      "metric": 10,
       "nexthops": [
         {
           "active": true,

--- a/isis-topo1/r4/r4_topology.json
+++ b/isis-topo1/r4/r4_topology.json
@@ -108,15 +108,7 @@
           "next-hop": "10",
           "parent": "r4-eth1",
           "type": "IP6",
-          "vertex": "2001:db8:1:1::/64"
-        },
-        {
-          "interface": "r5",
-          "metric": "internal",
-          "next-hop": "10",
-          "parent": "r4-eth1",
-          "type": "IP6",
-          "vertex": "2001:db8:1:2::/64"
+          "vertex": "2001:db8:2:1::/64"
         },
         {
           "interface": "r5",

--- a/isis-topo1/r5/r5_route6.json
+++ b/isis-topo1/r5/r5_route6.json
@@ -1,55 +1,55 @@
 {
-  "2001:db8:1:1::/64": [
-    {
-      "nexthops": [
-        {
-          "active": true,
-          "directlyConnected": true,
-          "fib": true,
-          "interfaceIndex": 2,
-          "interfaceName": "r5-eth0"
-        }
-      ],
-      "prefix": "2001:db8:1:1::/64",
-      "protocol": "connected",
-      "selected": true
-    }
-  ],
-  "2001:db8:1:2::/64": [
-    {
-      "nexthops": [
-        {
-          "active": true,
-          "directlyConnected": true,
-          "fib": true,
-          "interfaceIndex": 3,
-          "interfaceName": "r5-eth1"
-        }
-      ],
-      "prefix": "2001:db8:1:2::/64",
-      "protocol": "connected",
-      "selected": true
-    }
-  ],
   "2001:db8:2:1::/64": [
     {
-      "distance": 115,
-      "metric": 10,
       "nexthops": [
         {
           "active": true,
-          "afi": "ipv6",
+          "directlyConnected": true,
           "fib": true,
           "interfaceIndex": 2,
           "interfaceName": "r5-eth0"
         }
       ],
       "prefix": "2001:db8:2:1::/64",
-      "protocol": "isis",
+      "protocol": "connected",
       "selected": true
     }
   ],
   "2001:db8:2:2::/64": [
+    {
+      "nexthops": [
+        {
+          "active": true,
+          "directlyConnected": true,
+          "fib": true,
+          "interfaceIndex": 3,
+          "interfaceName": "r5-eth1"
+        }
+      ],
+      "prefix": "2001:db8:2:2::/64",
+      "protocol": "connected",
+      "selected": true
+    }
+  ],
+  "2001:db8:1:1::/64": [
+    {
+      "distance": 115,
+      "metric": 10,
+      "nexthops": [
+        {
+          "active": true,
+          "afi": "ipv6",
+          "fib": true,
+          "interfaceIndex": 2,
+          "interfaceName": "r5-eth0"
+        }
+      ],
+      "prefix": "2001:db8:1:1::/64",
+      "protocol": "isis",
+      "selected": true
+    }
+  ],
+  "2001:db8:1:2::/64": [
     {
       "distance": 115,
       "metric": 10,
@@ -62,7 +62,7 @@
           "interfaceName": "r5-eth1"
         }
       ],
-      "prefix": "2001:db8:2:2::/64",
+      "prefix": "2001:db8:1:2::/64",
       "protocol": "isis",
       "selected": true
     }

--- a/isis-topo1/r5/r5_route6_linux.json
+++ b/isis-topo1/r5/r5_route6_linux.json
@@ -1,15 +1,15 @@
 {
   "2001:db8:2:1::/64": {
     "dev": "r5-eth0",
-    "metric": "20",
+    "metric": "256",
     "pref": "medium",
-    "proto": "187"
+    "proto": "kernel"
   },
   "2001:db8:2:2::/64": {
     "dev": "r5-eth1",
-    "metric": "20",
+    "metric": "256",
     "pref": "medium",
-    "proto": "187"
+    "proto": "kernel"
   },
   "2001:db8:f::3": {
     "dev": "r5-eth0",

--- a/isis-topo1/r5/zebra.conf
+++ b/isis-topo1/r5/zebra.conf
@@ -1,11 +1,11 @@
 hostname r5
 interface r5-eth0
  ip address 10.0.10.1/24
- ipv6 address 2001:db8:1:1::4/64
+ ipv6 address 2001:db8:2:1::1/64
 !
 interface r5-eth1
  ip address 10.0.11.1/24
- ipv6 address 2001:db8:1:2::4/64
+ ipv6 address 2001:db8:2:2::1/64
 !
 interface lo
  ip address 10.254.0.5/32


### PR DESCRIPTION
The v6 isis topology didn't match the description and illustration. This adjusts the isis configurations and the expected test results so that everything is in agreement.

Signed-off-by: Mark Stapp <mjs@voltanet.io>