### PR TITLE
topotests: test timers improvements

### DIFF
--- a/lib/topotest.py
+++ b/lib/topotest.py
@@ -199,6 +199,24 @@ def json_cmp(d1, d2):
     return None
 
 
+def router_output_cmp(router, cmd, expected):
+    """
+    Runs `cmd` in router and compares the output with `expected`.
+    """
+    return difflines(normalize_text(router.vtysh_cmd(cmd)),
+                     normalize_text(expected),
+                     title1="Current output",
+                     title2="Expected output")
+
+
+def router_json_cmp(router, cmd, data):
+    """
+    Runs `cmd` that returns JSON data (normally the command ends with 'json')
+    and compare with `data` contents.
+    """
+    return json_cmp(router.vtysh_cmd(cmd, isjson=True), data)
+
+
 def run_and_expect(func, what, count=20, wait=3):
     """
     Run `func` and compare the result with `what`. Do it for `count` times
@@ -207,6 +225,12 @@ def run_and_expect(func, what, count=20, wait=3):
 
     Returns (True, func-return) on success or
     (False, func-return) on failure.
+
+    ---
+
+    Helper functions to use with this function:
+    - router_output_cmp
+    - router_json_cmp
     """
     start_time = time.time()
     func_name = "<unknown>"

--- a/lib/topotest.py
+++ b/lib/topotest.py
@@ -297,10 +297,16 @@ def get_file(content):
 
 def normalize_text(text):
     """
-    Strips formating spaces/tabs and carriage returns.
+    Strips formating spaces/tabs, carriage returns and trailing whitespace.
     """
     text = re.sub(r'[ \t]+', ' ', text)
     text = re.sub(r'\r', '', text)
+
+    # Remove whitespace in the middle of text.
+    text = re.sub(r'[ \t]+\n', '\n', text)
+    # Remove whitespace at the end of the text.
+    text = text.rstrip()
+
     return text
 
 def module_present(module, load=True):


### PR DESCRIPTION
Based on Lou's feedback, I'm implementing some ideias to better display test duration and reduce CI system instabilities.

First step is to improve the `run_and_expect` function, then figure out recurring paterns to create functions that can be reused.

Example of recurring patterns:
* Compare router output with file (text);
* Compare router output with file (JSON);
* Compare linux output with file (e.g. `ip route`);

Another improvements that may enter here:
* Reduce protocol timers to avoid `sleep` code;
* Start routers/hosts/exabgp concurrently instead of waiting one by one;