### PR TITLE
ospf-topo1-vrf: show errors and reduce code

### DIFF
--- a/ospf-topo1/test_ospf_topo1.py
+++ b/ospf-topo1/test_ospf_topo1.py
@@ -334,7 +334,7 @@ def test_ospf_link_down():
         test_func = partial(
             topotest.router_output_cmp, rnode, 'show ip ospf route', expected)
         result, diff = topotest.run_and_expect(test_func, '',
-                                               count=160, wait=0.5)
+                                               count=140, wait=0.5)
         assert result, 'OSPF did not converge on {}:\n{}'.format(router, diff)
 
 def test_ospf_link_down_kernel_route():


### PR DESCRIPTION
Use standardized code and fix assert messages to include errors.

Signed-off-by: Rafael Zalamena <rzalamena@opensourcerouting.org>

---

This PR is a response to this CI system run failure:
https://ci1.netdef.org/browse/FRR-FRRPULLREQ-4931/

In this PR:
https://github.com/FRRouting/frr/pull/2875

Missing messages:

**test_ospf_topo1_vrf test_ospf_kernel_route**

```
AssertionError: OSPF IPv4 route mismatch in router "r1" assert False
E   AssertionError: OSPF IPv4 route mismatch in router "r1"
    assert False
```

**test_ospf_topo1_vrf test_ospf_link_down_kernel_route**

```
AssertionError: OSPF IPv4 route mismatch in router "r1" after link down assert False
E   AssertionError: OSPF IPv4 route mismatch in router "r1" after link down
    assert False
```