### PR TITLE
lib: fix bad usage of strip() command

### DIFF
--- a/lib/topotest.py
+++ b/lib/topotest.py
@@ -428,7 +428,7 @@ def ip4_route_zebra(node, vrf_name=None):
 
     lines = output.splitlines()
     header_found = False
-    while lines and (not strip(lines[0])
+    while lines and (not lines[0].strip()
                         or not header_found):
         if '> - selected route' in lines[0]:
             header_found = True


### PR DESCRIPTION
This fix an issue with strip() command on library.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>