### PR TITLE
docker: add support for running inside container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,55 @@
+FROM ubuntu:18.04
+
+# Update system repos
+RUN DEBIAN_FRONTEND=noninteractive apt update
+
+# Install FRR dependencies
+RUN DEBIAN_FRONTEND=noninteractive apt install -y \
+      autoconf binutils bison flex libtool libjson-c-dev \
+      libpython-dev libreadline-dev libc-ares-dev python-sphinx \
+      install-info pkg-config texinfo
+
+# Install useful tools for debugging
+RUN DEBIAN_FRONTEND=noninteractive apt install -y \
+      gdb inetutils-ping iproute2 valgrind
+
+# Install mininet dependencies
+RUN DEBIAN_FRONTEND=noninteractive apt install -y \
+      mininet python-pip && \
+      pip install ipaddr pytest exabgp==3.4.17
+
+# Install user utilities
+RUN DEBIAN_FRONTEND=noninteractive apt install -y \
+      x11-xserver-utils xterm tmux vim tcpdump less man rsync
+
+# Configure FRR users
+RUN groupadd -r -g 92 frr && \
+      groupadd -r -g 85 frrvty && \
+      useradd -c "FRRouting suite" -d /var/run/frr -g frr -G frrvty \
+        -r -s /sbin/nologin frr
+
+# Configure exabgp user.
+RUN useradd -d /var/run/exabgp/ -s /bin/false exabgp
+
+# Configure coredumps.
+RUN echo "" >> /etc/security/limits.conf; \
+    echo "* soft core unlimited" >> /etc/security/limits.conf; \
+    echo "root soft core unlimited" >> /etc/security/limits.conf; \
+    echo "* hard core unlimited" >> /etc/security/limits.conf; \
+    echo "root hard core unlimited" >> /etc/security/limits.conf
+
+# Copy run scripts to facilitate users wanting to run the tests
+COPY . /opt/topotests
+WORKDIR /root
+
+RUN echo "cat /opt/topotests/motd.txt" >> /root/.profile && \
+      echo "export PS1='(topotests) $PS1'" >> /root/.profile
+
+# Configure volumes
+VOLUME [ "/root/frr", "/root/topotests" ]
+
+# Add topotests script directory to path
+ENV PATH "$PATH:/opt/topotests"
+
+# Use our custom entrypoint script
+ENTRYPOINT [ "bash", "/opt/topotests/entrypoint.sh" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,23 @@
+# Topotests in Docker
+
+This is folder contains auxiliary scripts to automate or help deploying
+topology tests under Docker on a standardized Ubuntu environment.
+
+Files description:
+
+* _funcs.sh_: shared bash code
+* _docker.sh_: builds docker image to run topotests
+* _compile_frr.sh_: compile FRR sources (should be used by `topotests_run.sh`)
+* _topotests_run.sh_: runs topotest image with the selected command
+
+## Running Topotests in Docker
+
+All you need to run topotests in Docker is:
+
+* Have Docker installed (tested against docker-ce[1])
+* Build the topotest images
+* Have the FRR/Topotest sources cloned in your machine
+
+Review and configure your sources folder in `topotests_run.sh`.
+
+[1]: https://docs.docker.com/install/linux/docker-ce/ubuntu/

--- a/docker/compile_frr.sh
+++ b/docker/compile_frr.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+#
+# Copyright 2018 Network Device Education Foundation, Inc. ("NetDEF")
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Load shared functions
+CDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. $CDIR/funcs.sh
+
+#
+# Script begin
+#
+if [ ! -f .sync_source -o $SYNC_SOURCE -ne 0 ]; then
+  log_info "Syncing FRR source with host..."
+  mkdir -p $FRR_BUILD_DIR >/dev/null 2>&1
+  rsync -a --info=progress2 --chown root:root $FRR_DIR/. $FRR_BUILD_DIR/
+  touch .sync_source
+fi
+
+log_info "Building FRR..."
+
+cd $FRR_BUILD_DIR || \
+  log_fatal "failed to find frr directory"
+
+if [ $CLEAN -ne 0 ]; then
+  make distclean >/dev/null 2>&1
+  rm -f Makefile configure
+fi
+
+if [ ! -f configure ]; then
+  bash bootstrap.sh || \
+    log_fatal "failed to bootstrap configuration"
+fi
+
+if [ $DOC -ne 0 ]; then
+  EXTRA_CONFIGURE+=" --enable-doc "
+else
+  EXTRA_CONFIGURE+=" --disable-doc "
+fi
+
+if [ ! -f Makefile ]; then
+  if [ $SANITIZER -ne 0 ]; then
+    export CC="gcc"
+    export CFLAGS="-O1 -g -fsanitize=address -fno-omit-frame-pointer"
+    export LD="gcc"
+    export LDFLAGS="-g -fsanitize=address -ldl"
+    EXTRA_CONFIGURE+=" --enable-shared=no "
+    touch .address_sanitizer
+  else
+    rm -f .address_sanitizer
+  fi
+
+  bash configure >/dev/null \
+    --enable-multipath=64 \
+    --prefix=/usr \
+    --localstatedir=/var/run/frr \
+    --sbindir=/usr/lib/frr \
+    --sysconfdir=/etc/frr \
+    $EXTRA_CONFIGURE \
+    --with-pkg-extra-version=-topotests \
+    || log_fatal "failed to configure the sources"
+fi
+
+# if '.address_sanitizer' file exists it means we are using address sanitizer.
+if [ -f .address_sanitizer ]; then
+  make -C lib CFLAGS="-g -O2" LDFLAGS="-g" clippy
+fi
+
+if [ $VERBOSE -ne 0 ]; then
+  make -j$(cpu_count) || \
+    log_fatal "failed to build the sources"
+else
+  make -j$(cpu_count) >/dev/null || \
+    log_fatal "failed to build the sources"
+fi
+
+make install >/dev/null || \
+  log_fatal "failed to install frr"
+
+exit 0

--- a/docker/docker.sh
+++ b/docker/docker.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Copyright 2018 Network Device Education Foundation, Inc. ("NetDEF")
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Load shared functions
+CDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. $CDIR/funcs.sh
+
+#
+# Script begin
+#
+
+OLD_IMAGE_SHA=$( \
+  docker images | \
+  egrep "^topotests" | \
+  sed -r "s/( )+/ /g" | \
+  cut -d " " -f 3 \
+)
+
+docker build --force-rm --pull --compress -t topotests . || \
+  log_fatal "failed to generate topotest docker image"
+
+if [ ! -z "$OLD_IMAGE_SHA" ]; then
+  log_info "Removing old topotest image"
+  docker rmi $OLD_IMAGE_SHA || \
+    log_warning "failed to remove old image"
+fi
+
+exit 0

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# Copyright 2018 Network Device Education Foundation, Inc. ("NetDEF")
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Load shared functions
+CDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. $CDIR/funcs.sh
+
+#
+# Script begin
+#
+log_info "Configuring OpenvSwitch...."
+
+# Configure OpenvSwitch so we are able to run mininet
+mkdir -p /var/run/openvswitch
+ovsdb-tool create /etc/openvswitch/conf.db \
+  /usr/share/openvswitch/vswitch.ovsschema
+ovsdb-server /etc/openvswitch/conf.db \
+  --remote=punix:/var/run/openvswitch/db.sock \
+  --remote=ptcp:6640 --pidfile=ovsdb-server.pid >/dev/null 2>/dev/null & \
+  disown
+ovs-vswitchd >/dev/null 2>/dev/null & disown
+
+sleep 2
+
+ovs-vsctl --no-wait -- init
+ovs_version=$(ovs-vsctl -V | grep ovs-vsctl | awk '{print $4}')
+ovs_db_version=$(\
+  ovsdb-tool schema-version /usr/share/openvswitch/vswitch.ovsschema)
+ovs-vsctl --no-wait -- set Open_vSwitch . db-version="${ovs_db_version}"
+ovs-vsctl --no-wait -- set Open_vSwitch . ovs-version="${ovs_version}"
+ovs-vsctl --no-wait -- set Open_vSwitch . system-type="docker-ovs"
+ovs-vsctl --no-wait -- set Open_vSwitch . system-version="0.1"
+ovs-vsctl --no-wait -- \
+  set Open_vSwitch . external-ids:system-id=`cat /proc/sys/kernel/random/uuid`
+ovs-vsctl --no-wait -- set-manager ptcp:6640
+ovs-appctl -t ovsdb-server \
+  ovsdb-server/add-remote db:Open_vSwitch,Open_vSwitch,manager_options
+
+# Build FRR
+env \
+  CLEAN=1 \
+  VERBOSE=0 \
+  bash /opt/topotests/compile_frr.sh
+
+log_info "Setting permissions on /tmp so we can generate logs"
+chmod -v 1777 /tmp
+
+log_info "Starting bash shell to interact with topotests"
+echo ''
+
+tmux
+
+log_info "Stopping OpenvSwitch"
+service openvswitch-switch stop

--- a/docker/funcs.sh
+++ b/docker/funcs.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# Copyright 2018 Network Device Education Foundation, Inc. ("NetDEF")
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+FRR_DIR=/root/frr
+FRR_BUILD_DIR=/root/frr-build
+TOPOTESTS_DIR=/root/topotests
+
+[ -z $CLEAN ] && CLEAN=0
+[ -z $VERBOSE ] && VERBOSE=1
+[ -z $DOC ] && DOC=0
+[ -z $SANITIZER ] && SANITIZER=1
+[ -z $SYNC_SOURCE ] && SYNC_SOURCE=0
+
+log_info() {
+  local msg=$1
+
+  echo -e "=> $msg"
+}
+
+log_error() {
+  local msg=$1
+
+  echo -e "E: $msg" 2>&1
+}
+
+log_warning() {
+  local msg=$1
+
+  echo -e "W: $msg" 2>&1
+}
+
+log_fatal() {
+  local msg=$1
+
+  echo -e "F: $msg" 2>&1
+
+  exit 1
+}
+
+cpu_count() {
+  local cpu_count
+
+  cpu_count=$(cat /proc/cpuinfo  | grep -w processor | wc -l)
+  if [ $? -eq 0 ]; then
+    echo -n $cpu_count
+  else
+    echo -n 2
+  fi
+}

--- a/docker/motd.txt
+++ b/docker/motd.txt
@@ -1,0 +1,20 @@
+Welcome to the topotests container.
+
+Here are some useful tips:
+* After changing the FRR/Topotests sources, you may rebuild them
+  using the command `compile_frr.sh`. The build command has the
+  following environment variables:
+  - CLEAN: whether we should distclean or not (disabled by default)
+  - VERBOSE: show build messages (enabled by default)
+  - DOC: whether we should build docs or not (disabled by default)
+  - SANITIZER: whether we should use the address sanitizer (enabled by default)
+  - SYNC_SOURCE: copy new changes from host FRR sources (disabled by default)
+
+  Usage example: env CLEAN=1 SYNC_SOURCE=1 DOC=1 compile_frr.sh
+
+* The topotests log directory can be found on your host machine on
+  `/tmp/topotests_logs`.
+
+* You may open an `xterm` inside the container. We do our best to detect
+  the X session on your host machine
+

--- a/docker/topotests_run.sh
+++ b/docker/topotests_run.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# Copyright 2018 Network Device Education Foundation, Inc. ("NetDEF")
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+# Source folders
+FRR_DIR=$HOME/src/frr
+TOPOTESTS_DIR=$HOME/src/topotests
+
+
+#
+# Script begin
+#
+CMD=$1
+if [ -z $1 ]; then
+  CMD=bash
+fi
+
+docker run --rm -ti \
+  -v "/lib/modules:/lib/modules" \
+  -v "/tmp/topotests_logs:/tmp" \
+  -v "$FRR_DIR:/root/frr:ro" \
+  -v "$TOPOTESTS_DIR:/root/topotests:ro" \
+  -v "/tmp/.X11-unix:/tmp/.X11-unix" \
+  -v "$HOME/.Xauthority:/root/.Xauthority" \
+  -e DISPLAY=$DISPLAY \
+  --net=host \
+  --privileged \
+  topotests
+
+exit 0

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 # Skip pytests example directory
 [pytest]
-norecursedirs = .git example-test lib
+norecursedirs = .git example-test lib docker
 
 [topogen]
 # Default configuration values


### PR DESCRIPTION
### Summary

This PR adds a topotests Dockerfile and scripts to instantiate a standardized testing environment to help people with trouble running topotest on their Linux environment.

Pros:
* Same packages installed as the developers use (e.g. same development environment);
* Don't clutters the host machine;
* Runs on Mac OS X (and maybe others OSes) without having to manage VMs;

Cons:
* May not run all tests due missing kernel modules (or requires some manual intervention);
* Adds an indirection layer to access the FRR/Topotest files (it is not running directly on host);
* Probably will use duplicated space if you have all packages in the host;

### TODOs

The current implementation is adapted to my workflow and may be simplified to be more user-friendly. Here are some suggestions I've got from feedback:

* Allow `topotest_run.sh` to run tests directly instead of dropping the user into a `bash` shell;
* Cache FRR binaries between images execution to avoid rebuilding it (doesn't affect users which use the interactive shell);
* Script to access / debug topotest routers on tests failures (e.g. open a bash shell inside the name space. @cfra suggested the following: https://gist.github.com/cfra/39f4110366fa1ae9b1bddd1b47f586a3 )
* (BUG) Docker image build script removes topotest image when the build doesn't do anything (e.g. uses cache). See `docker.sh` script.