### PR TITLE
ospf6-topo1: Don't compare link-local routes

### DIFF
--- a/ospf6-topo1/r1/ip_6_address.ref
+++ b/ospf6-topo1/r1/ip_6_address.ref
@@ -8,6 +8,3 @@ fc00:4444:4444:4444::/64 via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 
 fc00:4:4:4::/64 via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
 fc00:a:a:a::/64 dev r1-sw5 proto XXXX metric 256 pref medium
 fc00:b:b:b::/64 via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
-fe80::/64 dev r1-stubnet proto XXXX metric 256 pref medium
-fe80::/64 dev r1-sw5 proto XXXX metric 256 pref medium
-unreachable fe80::/64 dev lo proto XXXX metric 256 error -101 pref medium

--- a/ospf6-topo1/r2/ip_6_address.ref
+++ b/ospf6-topo1/r2/ip_6_address.ref
@@ -8,6 +8,3 @@ fc00:4444:4444:4444::/64 via fe80::__(r3-sw5)__ dev r2-sw5 proto XXXX metric 20 
 fc00:4:4:4::/64 via fe80::__(r3-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
 fc00:a:a:a::/64 dev r2-sw5 proto XXXX metric 256 pref medium
 fc00:b:b:b::/64 via fe80::__(r3-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
-fe80::/64 dev r2-stubnet proto XXXX metric 256 pref medium
-fe80::/64 dev r2-sw5 proto XXXX metric 256 pref medium
-unreachable fe80::/64 dev lo proto XXXX metric 256 error -101 pref medium

--- a/ospf6-topo1/r3/ip_6_address.ref
+++ b/ospf6-topo1/r3/ip_6_address.ref
@@ -8,7 +8,3 @@ fc00:4444:4444:4444::/64 via fe80::__(r4-sw6)__ dev r3-sw6 proto XXXX metric 20 
 fc00:4:4:4::/64 via fe80::__(r4-sw6)__ dev r3-sw6 proto XXXX metric 20 pref medium
 fc00:a:a:a::/64 dev r3-sw5 proto XXXX metric 256 pref medium
 fc00:b:b:b::/64 dev r3-sw6 proto XXXX metric 256 pref medium
-fe80::/64 dev r3-stubnet proto XXXX metric 256 pref medium
-fe80::/64 dev r3-sw5 proto XXXX metric 256 pref medium
-fe80::/64 dev r3-sw6 proto XXXX metric 256 pref medium
-unreachable fe80::/64 dev lo proto XXXX metric 256 error -101 pref medium

--- a/ospf6-topo1/r4/ip_6_address.ref
+++ b/ospf6-topo1/r4/ip_6_address.ref
@@ -8,6 +8,3 @@ fc00:4444:4444:4444::/64 via fc00:4:4:4::1234 dev r4-stubnet proto XXXX metric 2
 fc00:4:4:4::/64 dev r4-stubnet proto XXXX metric 256 pref medium
 fc00:a:a:a::/64 via fe80::__(r3-sw6)__ dev r4-sw6 proto XXXX metric 20 pref medium
 fc00:b:b:b::/64 dev r4-sw6 proto XXXX metric 256 pref medium
-fe80::/64 dev r4-stubnet proto XXXX metric 256 pref medium
-fe80::/64 dev r4-sw6 proto XXXX metric 256 pref medium
-unreachable fe80::/64 dev lo proto XXXX metric 256 error -101 pref medium

--- a/ospf6-topo1/test_ospf6_topo1.py
+++ b/ospf6-topo1/test_ospf6_topo1.py
@@ -345,8 +345,13 @@ def test_linux_ipv6_kernel_routingTable():
             actual = actual.rstrip()
             actual = re.sub(r'  +', ' ', actual)
 
-            # Fix newlines (make them all the same)
-            actual = ('\n'.join(sorted(actual.splitlines()))).splitlines(1)
+            filtered_lines = []
+            for line in sorted(actual.splitlines()):
+                if line.startswith('fe80::/64 ') \
+                        or line.startswith('unreachable fe80::/64 '):
+                    continue
+                filtered_lines.append(line)
+            actual = '\n'.join(filtered_lines).splitlines(1)
 
             # Print Actual table
             # print("Router r%s table" % i)


### PR DESCRIPTION
Topotests would fail with errors like these:

    AssertionError: Linux Kernel IPv6 Routing Table verification failed for router r1:
      --- actual OSPFv3 IPv6 routing table
      +++ expected OSPFv3 IPv6 routing table
      @@ -8,6 +8,6 @@
       fc00:4:4:4::/64 via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
       fc00:a:a:a::/64 dev r1-sw5 proto XXXX metric 256 pref medium
       fc00:b:b:b::/64 via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
      -fe80::/64 dev lo proto XXXX metric 256 pref medium
       fe80::/64 dev r1-stubnet proto XXXX metric 256 pref medium
      -fe80::/64 dev r1-sw5 proto XXXX metric 256 pref medium
      +fe80::/64 dev r1-sw5 proto XXXX metric 256 pref medium
      +unreachable fe80::/64 dev lo proto XXXX metric 256 error -101 pref medium

Resolve this by not comparing link-local routes.

Signed-off-by: Christian Franke <chris@opensourcerouting.org>