### PR TITLE
bugfix: Fail on compile error

### DIFF
--- a/docker/inner/entrypoint.sh
+++ b/docker/inner/entrypoint.sh
@@ -26,6 +26,8 @@
 CDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . $CDIR/funcs.sh
 
+set -e
+
 #
 # Script begin
 #


### PR DESCRIPTION
The default entrypoint should exit if FRR fails to compile.