### PR TITLE
docker: Improve README and frr-topotests usage

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -30,8 +30,8 @@ of the image. If you need to force a complete recompile, you can set `TOPOTEST_C
 TOPOTEST_CLEAN=1 frr-topotests
 ```
 
-By default, `frr-topotests` will execute pytest without any arguments. If you append an
-arguments with the first one starting with `/` or `./`, they will replace the call to
+By default, `frr-topotests` will build frr and run pytest. If you append
+arguments and the first one starts with `/` or `./`, they will replace the call to
 pytest. If the appended arguments do not match this patttern, they will be provided to
 pytest as arguments.
 

--- a/docker/frr-topotests.sh
+++ b/docker/frr-topotests.sh
@@ -32,7 +32,11 @@ if [[ "$1" = "-h" ]] || [[ "$1" = "--help" ]]; then
 
 	Usage: $0 [args...]
 
-	Its behavior can be modified by the following environment variables:
+	If any arguments are provided and the first argument starts with / or ./
+	the arguments are interpreted as command and will be executed instead
+	of pytest.
+
+	Behavior can be further modified by the following environment variables:
 
 	TOPOTEST_AUTOLOAD       If set to 1, the script will try to load necessary
 	                        kernel modules without asking for confirmation first.
@@ -66,8 +70,6 @@ if [[ "$1" = "-h" ]] || [[ "$1" = "--help" ]]; then
 	TOPOTEST_VERBOSE        Show detailed build output.
 	                        Enabled by default, set to 0 to disable.
 
-	To get information about the commands available inside of the container,
-	run \`$0 help\`.
 	EOF
 	exit 1
 fi


### PR DESCRIPTION
Signed-off-by: Christian Franke <chris@opensourcerouting.org>