### PR TITLE
Add a tiny breadcrumb to hopefully help end user

### DIFF
--- a/lib/topotest.py
+++ b/lib/topotest.py
@@ -933,6 +933,10 @@ class Router(Node):
         for daemon in self.daemons:
             if (self.daemons[daemon] == 1) and not (daemon in daemonsRunning):
                 sys.stderr.write("%s: Daemon %s not running\n" % (self.name, daemon))
+                if daemon is "staticd":
+                    sys.stderr.write("You may have a copy of staticd installed but are attempting to test against\n")
+                    sys.stderr.write("a version of FRR that does not have staticd, please cleanup the install dir\n")
+
                 # Look for core file
                 corefiles = glob.glob('{}/{}/{}_core*.dmp'.format(
                     self.logdir, self.name, daemon))


### PR DESCRIPTION
Add a breadcrumb for people testing to hopefully allow
them to figure out what is going wrong when they
are testing different versions of FRR using
topotests and staticd is not running because
this version of staticd needs to be cleaned up

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>