### PR TITLE
topotests: cherry-pick fix for PR #3811

### DIFF
--- a/all-protocol-startup/r1/show_bgp_ipv6_summary.ref
+++ b/all-protocol-startup/r1/show_bgp_ipv6_summary.ref
@@ -1,7 +1,7 @@
 BGP router identifier 192.168.0.1, local AS number 100 vrf-id 0
 BGP table version 1
 RIB entries 1, using XXXX bytes of memory
-Peers 4, using XXXX KiB of memory
+Peers 2, using XXXX KiB of memory
 
 Neighbor         V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
 fc00:0:0:8::1000 4        100       0       0        0    0    0    never       Active


### PR DESCRIPTION
Since this fix is being backported to 6.0 the topotests need to be
updated here as well.

See: https://github.com/FRRouting/frr/pull/3811

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>